### PR TITLE
Fix dev-perl/YAML dependencies

### DIFF
--- a/dev-perl/RedisFailover/RedisFailover-9999.ebuild
+++ b/dev-perl/RedisFailover/RedisFailover-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -17,7 +17,7 @@ IUSE=""
 DEPEND="
 	dev-perl/Moo
 	dev-perl/Redis
-	dev-perl/yaml
+	dev-perl/YAML
 	dev-perl/Linux-Inotify2
 	dev-perl/Module-Build
 "

--- a/dev-perl/Ruby-VersionManager/Ruby-VersionManager-9999.ebuild
+++ b/dev-perl/Ruby-VersionManager/Ruby-VersionManager-9999.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -16,7 +16,7 @@ IUSE=""
 
 DEPEND="
 	dev-perl/Moo
-	dev-perl/yaml
+	dev-perl/YAML
 	dev-perl/libwww-perl"
 
 RDEPEND="${DEPEND}"


### PR DESCRIPTION
dev-perl/yaml was renamed to dev-perl/YAML
=> updated the DEPEND and RDEPEND sections

Package-Manager: portage-2.2.26