### PR TITLE
app-misc/karmabot-bin: add missing metadata.xml

### DIFF
--- a/app-misc/karmabot-bin/metadata.xml
+++ b/app-misc/karmabot-bin/metadata.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+    <maintainer type="person">
+        <email>ops@adjust.com</email>
+    </maintainer>
+</pkgmetadata>


### PR DESCRIPTION
Lack of `metadata.xml` breaks tests not just for master branch, but also for all branches trying to fork from there (e.g. any new work), or trying to rebase on top of current master (e.g. in-progress work).

Please use `repoman commit` for committing your ebuild work to prevent such issues, and also please respect automated test results in case you forgot to use `repoman commit` :)