### PR TITLE
app-admin/schaufel: add postgresql as a dependency

### DIFF
--- a/app-admin/schaufel/schaufel-9999.ebuild
+++ b/app-admin/schaufel/schaufel-9999.ebuild
@@ -18,6 +18,7 @@ DEPEND=""
 RDEPEND="${DEPEND}
 >=dev-libs/librdkafka-0.9.4[lz4]
 dev-libs/hiredis
+dev-db/postgresql
 "
 
 pkg_setup() {


### PR DESCRIPTION
needed for libpq

Package-Manager: Portage-2.3.6, Repoman-2.3.1