### PR TITLE
net-analyzer/nmis: depend on <rrdtool-1.6

### DIFF
--- a/net-analyzer/nmis/nmis-4.3.7c.ebuild
+++ b/net-analyzer/nmis/nmis-4.3.7c.ebuild
@@ -34,7 +34,7 @@ RDEPEND="${DEPEND}
 	dev-perl/TimeDate
 	dev-perl/Time-ParseDate
 	net-analyzer/fping
-	net-analyzer/rrdtool[perl,graph,rrdcgi]
+	<net-analyzer/rrdtool-1.6[perl,graph,rrdcgi]
 	virtual/perl-Data-Dumper
 	mysql? ( dev-perl/DBD-mysql )
 	postgres? ( dev-perl/DBD-Pg )


### PR DESCRIPTION
With rrdtool-1.6.0 nmis fails to generate graphs, e.g:
(Unlike rrdtool-1.5.5 which works as expected)

```
18-Jan-2018 13:32:59,rrdDraw,,RRDTool type=mem-router, database=/path/to/database4/health/router/$router.rrd Graphing Error: invalid option -- 'interlace' options=--title $router - 48 hours from 16-Jan-2018 13:32:59 to 18-Jan-2018 13:32:59 --vertical-label % Mem. Util. --start 1516109579 --end 1516282379 --width 500 --height 100 --imgformat PNG --interlace DEF:MemUsedD=/path/to/database4/health/router/$router.rrd:MemoryUsedPROC:AVERAGE DEF:MemFreeD=/path/to/database4/health/router/$router.rrd:MemoryFreePROC:AVERAGE DEF:MemUsedM=/path/to/database4/health/router/$router.rrd:MemoryUsedIO:AVERAGE DEF:MemFreeM=/path/to/database4/health/router/$router.rrd:MemoryFreeIO:AVERAGE CDEF:totalMemD=MemUsedD,MemFreeD,+ CDEF:perUsedMemD=MemUsedD,totalMemD,/,100,* CDEF:totalMemM=MemUsedM,MemFreeM,+ CDEF:perUsedMemM=MemUsedM,totalMemM,/,100,* LINE2:perUsedMemD#0000ff:% Proc Mem Used LINE2:perUsedMemM#00ff00:% IO Mem Used\n GPRINT:perUsedMemD:AVERAGE:Proc Mem Used %1.2lf %% GPRINT:perUsedMemM:AVERAGE:IO Mem Used %1.2lf %%\n GPRINT:MemUsedD:AVERAGE:Proc Mem Used %1.0lf bytes GPRINT:MemFreeD:AVERAGE:Proc Mem Free %1.0lf bytes GPRINT:totalMemD:AVERAGE:Total Proc Mem %1.0lf bytes\n GPRINT:MemUsedM:AVERAGE:IO Mem Used %1.0lf bytes GPRINT:MemFreeM:AVERAGE:IO Mem Free %1.0lf bytes GPRINT:totalMemM:AVERAGE:Total IO Mem %1.0lf bytes
```