### PR TITLE
dev-db/vire: Initial ebuild

### DIFF
--- a/dev-db/vire/metadata.xml
+++ b/dev-db/vire/metadata.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer type="person">
+		<email>ops@adjust.com</email>
+	</maintainer>
+</pkgmetadata>

--- a/dev-db/vire/vire-9999.ebuild
+++ b/dev-db/vire/vire-9999.ebuild
@@ -1,0 +1,34 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI="6"
+
+WANT_AUTOMAKE="1.15"
+inherit git-r3 autotools
+
+DESCRIPTION="Multithreaded in-memory database that talks redis protocol"
+HOMEPAGE="https://github.com/vipshop/vire"
+LICENSE="Apache-2.0"
+
+EGIT_REPO_URI="https://github.com/vipshop/vire.git"
+
+SLOT=0
+IUSE=""
+KEYWORDS="~amd64"
+
+DEPEND=""
+#	dev-libs/jemalloc
+#	dev-libs/hiredis
+#	"
+
+src_prepare() {
+	#rm -rf dep/hiredis* dep/jemalloc*
+	#eautoreconf # this fails
+	autoreconf -vfi # this fails less
+	eapply_user
+}
+
+src_compile() {
+	unset ARCH
+	emake
+}


### PR DESCRIPTION
Build system is mildly insane, bundles jemalloc and
libhiredis.

Installs some stuff to /usr/local

Very bleh :)

Package-Manager: Portage-2.3.35, Repoman-2.3.9