### PR TITLE
shiny-server: user shiny mustn't own shiny-server config

### DIFF
--- a/www-apps/shiny-server/shiny-server-1.5.6.875.ebuild
+++ b/www-apps/shiny-server/shiny-server-1.5.6.875.ebuild
@@ -58,8 +58,6 @@ src_install() {
 	doins "${WORKDIR}/${PF}"/config/*
 	doins "${FILESDIR}/shiny-server.conf"
 
-	fowners -R shiny:shiny /etc/shiny-server
-
 	dodir /var/log/shiny-server
 	fowners -R shiny:shiny /var/log/shiny-server
 


### PR DESCRIPTION
Shouldn't be able to change its own config (what if somebody exploits shiny server).