### PR TITLE
Bagger tools init

### DIFF
--- a/app-admin/bagger-tools/bagger-tools-9999.ebuild
+++ b/app-admin/bagger-tools/bagger-tools-9999.ebuild
@@ -10,7 +10,7 @@ SRC_URI=""
 EGIT_REPO_URI="https://github.com/adjust/bagger.git"
 SLOT="0"
 KEYWORDS=""
-IUSE=""
+IUSE="schaufel"
 
 DEPEND="
 	dev-perl/Moo
@@ -24,6 +24,19 @@ DEPEND="
 	dev-perl/Digest-SHA1
 "
 
-RDEPEND="${DEPEND}"
+RDEPEND="${DEPEND}
+	schaufel? (
+		app-admin/schaufel
+	)
+"
 
-mytargets="install"
+src_install() {
+	mytargets="install"
+	perl-module_src_install
+
+	if use schaufel;
+	then
+		newinitd "${FILESDIR}"/schaufel_listener.initd schaufel_listener
+		newconfd "${FILESDIR}"/schaufel_listener.confd schaufel_listener
+	fi
+}

--- a/app-admin/bagger-tools/files/schaufel_listener.confd
+++ b/app-admin/bagger-tools/files/schaufel_listener.confd
@@ -1,0 +1,18 @@
+############################################
+#Listener daemon settings
+
+#LISTENER_DIR="/var/lib/schaufel"
+#LISTENER_LOG_DIR="/var/log/schaufel"
+#LISTENER_LOG_FILE="schaufel_listener.log"
+#LISTENER_USER=schaufel
+#LISTENER_GROUP=schaufel
+#LISTENER_TIMEOUT=60
+
+############################################
+#Listener settings passed to schaufel
+
+#LISTENER_MASTER="host:port"
+#LISTENER_TOPIC="kafka topic"
+#LISTENER_BROKER_GROUP="kafka group"
+#LISTENER_BROKER="host:port"
+#LISTENER_JOBS=4

--- a/app-admin/bagger-tools/files/schaufel_listener.initd
+++ b/app-admin/bagger-tools/files/schaufel_listener.initd
@@ -1,0 +1,65 @@
+#!/sbin/openrc-run
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+TOPIC=${SVCNAME#*.}
+
+if [ -n "${TOPIC}" ] && [ "${SVCNAME}" != "schaufel_listener" ]
+then
+	LISTENER_PID="/run/schaufel_listener/${TOPIC}.pid"
+else
+	LISTENER_PID="/run/schaufel_listener/schaufel_listener.pid"
+
+	# For now, the default behaviour is to consume the old bagger topic
+	TOPIC="bagger3"
+	LISTENER_BROKER_GROUP="bagger2"
+	LISTENER_JOBS="8"
+fi
+
+LISTENER_DIR=${LISTENER_DIR:-/var/lib/schaufel}
+LISTENER_LOG_DIR=${LISTENER_LOG_DIR:-/var/log/schaufel}
+LISTENER_LOG_FILE="${LISTENER_LOG_DIR}/${LISTENER_LOG_FILE:-${SVCNAME}.log}"
+LISTENER_USER=${LISTENER_USER:-schaufel}
+LISTENER_GROUP=${LISTENER_GROUP:-schaufel}
+LISTENER_TIMEOUT=${LISTENER_TIMEOUT:-60}
+
+LISTENER_OPTS="-m ${LISTENER_MASTER:-master-1:5432}"
+LISTENER_OPTS+=" -t ${LISTENER_TOPIC:-${TOPIC}}"
+[ -n "${LISTENER_BROKER_GROUP}" ] && \
+	LISTENER_OPTS+=" -g ${LISTENER_BROKER_GROUP}"
+[ -n "${LISTENER_BROKER}" ] && \
+	LISTENER_OPTS+=" -b ${LISTENER_BROKER}"
+[ -n "${LISTENER_JOBS}" ] && \
+	LISTENER_OPTS+=" -j ${LISTENER_JOBS}"
+
+command=/usr/bin/listener.pl
+command_args="${LISTENER_OPTS}"
+pidfile="${LISTENER_PID}"
+
+start_stop_daemon_args="--background \
+	--make-pidfile \
+	--verbose \
+	--chdir ${LISTENER_DIR} \
+	--user ${LISTENER_USER} \
+	--group ${LISTENER_GROUP} \
+	--stdout ${LISTENER_LOG_FILE} \
+	--stderr ${LISTENER_LOG_FILE}"
+
+depend() {
+	need localmount net
+	after postgresql
+}
+
+start_pre() {
+	checkpath -d -m 0775 -o ${LISTENER_USER}:${LISTENER_GROUP} "$(dirname ${pidfile})"
+	checkpath -f -m 0775 -o ${LISTENER_USER}:${LISTENER_GROUP} "${pidfile}"
+}
+
+stop() {
+	ebegin "Stopping ${SVCNAME}"
+	start-stop-daemon --stop \
+		--exec ${command} \
+		--retry TERM/${LISTENER_TIMEOUT}/SIGINT/5 \
+		--pidfile "${pidfile}"
+	eend
+}

--- a/app-admin/bagger-tools/metadata.xml
+++ b/app-admin/bagger-tools/metadata.xml
@@ -7,4 +7,7 @@
 	<longdescription lang="en">
 		Perl Postgres Dump and Restore Tools
 	</longdescription>
+	<use>
+		<flag name="schaufel">Init scripts for schaufel listener/schaufel dependency</flag>
+	</use>
 </pkgmetadata>


### PR DESCRIPTION
An init script for listener.pl, an updated listen.pl (signal handler and more argv parsing).

The Init script allows generating new kafka consumers by creating a symlink, e.g.:
ln -s schaufel_listener schaufel_listener.callback_worker_reattributions

This PR is related to several tickets, amongst them:
https://github.com/adjust/infrastructure/issues/2889
https://github.com/adjust/infrastructure/issues/3719