### PR TITLE
dev-db/metabase-bin: fix metabase-server-start.sh

### DIFF
--- a/dev-db/metabase-bin/files/metabase-server-start.sh
+++ b/dev-db/metabase-bin/files/metabase-server-start.sh
@@ -83,6 +83,6 @@ then
 fi
 
 # start the process and wait for the reaper
-java $EXTRA_ARGS -jar /opt/metabase/bin/metabase.jar &
+java $EXTRA_ARGS -jar /opt/metabase/bin/metabase-bin.jar &
 wait -n $!
 


### PR DESCRIPTION
old version of script starts the wrong binary