### PR TITLE
net-analyzer/clickhouse_exporter: ebuild for git head

### DIFF
--- a/net-analyzer/clickhouse_exporter/clickhouse_exporter-9999.ebuild
+++ b/net-analyzer/clickhouse_exporter/clickhouse_exporter-9999.ebuild
@@ -1,0 +1,33 @@
+# Copyright 1999-2019 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+RESTRICT="test"
+
+EGO_PN="github.com/f1yegor/${PN}"
+
+inherit golang-vcs golang-build user
+
+DESCRIPTION="Clickhouse Prometheus Exporter"
+HOMEPAGE="https://github.com/f1yegor/clickhouse_exporter"
+LICENSE="MIT"
+SLOT="0"
+IUSE=""
+
+EXPORTER_USER=clickhouse_exporter
+
+pkg_setup() {
+	enewuser "${EXPORTER_USER}" -1 -1 -1
+}
+
+src_install() {
+	newbin clickhouse_exporter "${PN}"
+	dodoc "src/${EGO_PN}/README.md"
+
+	keepdir /var/log/"${PN}"
+	fowners "${EXPORTER_USER}":"${EXPORTER_USER}" /var/log/"${PN}"
+
+	newinitd "${FILESDIR}/${PN}.initd" "${PN}"
+	newconfd "${FILESDIR}/${PN}.confd" "${PN}"
+}

--- a/net-analyzer/clickhouse_exporter/files/clickhouse_exporter.confd
+++ b/net-analyzer/clickhouse_exporter/files/clickhouse_exporter.confd
@@ -1,0 +1,16 @@
+# Accepts debug, info, warn, error, fatal, panic.
+#CE_LOG_LEVEL="error"
+
+# Ignore server certificate when using https
+#CE_INSECURE="true"
+
+# Clickhouse endpoint
+#CE_SCRAPE_URI="http://localhost:8123/"
+
+# Port and endpoint for telemetry
+#CE_TELEMETRY_ADDRESS=":9116"
+#CE_TELEMETRY_ENDPOINT="/metrics"
+
+# Credentials for Clickhouse
+#CLICKHOUSE_USER=
+#CLICKHOUSE_PASSWORD=

--- a/net-analyzer/clickhouse_exporter/files/clickhouse_exporter.initd
+++ b/net-analyzer/clickhouse_exporter/files/clickhouse_exporter.initd
@@ -1,0 +1,25 @@
+#!/sbin/openrc-run
+# Copyright 2019 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+name="clickhouse_exporter daemon"
+description="Clickhouse Exporter for Prometheus"
+command=/usr/bin/clickhouse_exporter
+command_args="-log.level ${CE_LOG_LEVEL:-error} \
+	-insecure ${CE_INSECURE:-true} \
+	-scrape_uri ${CE_SCRAPE_URI:-http://localhost:8123/} \
+	-telemetry.address ${CE_TELEMETRY_ADDRESS:-:9116} \
+	-telemetry.endpoint ${CE_TELEMETRY_ENDPOINT:-/metrics} \
+	${CLICKHOUSE_USER+-e CLICKHOUSE_USER=}${CLICKHOUSE_USER} \
+	${CLICKHOUSE_PASSWORD+-e CLICKHOUSE_PASSWORD=}${CLICKHOUSE_PASSWORD}"
+command_user="${RC_SVCNAME}"
+command_background="true"
+pidfile="/run/${RC_SVCNAME}"
+output_log="/var/log/${RC_SVCNAME}/${RC_SVCNAME}.log"
+error_log="/var/log/${RC_SVCNAME}/${RC_SVCNAME}.log"
+
+depend() {
+	need net
+	after net
+}
+

--- a/net-analyzer/clickhouse_exporter/metadata.xml
+++ b/net-analyzer/clickhouse_exporter/metadata.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+<maintainer type="person">
+<email>ops@adjust.com</email>
+</maintainer>
+</pkgmetadata>


### PR DESCRIPTION
From https://github.com/f1yegor/clickhouse_exporter. Upstream has no releases so using head.

Custom init.d and conf.d scripts.