### PR TITLE
bagger-tools init: set producer jobs when using a config

### DIFF
--- a/app-admin/bagger-tools/files/schaufel_listener-0.3.initd
+++ b/app-admin/bagger-tools/files/schaufel_listener-0.3.initd
@@ -36,13 +36,13 @@ else
 		LISTENER_OPTS+=" -g ${LISTENER_BROKER_GROUP}"
 	[ -n "${LISTENER_BROKER}" ] && \
 		LISTENER_OPTS+=" -b ${LISTENER_BROKER}"
-	[ -n "${LISTENER_JOBS}" ] && \
-		LISTENER_OPTS+=" -j ${LISTENER_JOBS}"
 fi
 	[ -n "${INFIX}" ] && \
 		LISTENER_OPTS+=" -i ${INFIX}"
 [ -n "${HOSTNAME_OVERRIDE}" ] && \
 		LISTENER_OPTS+=" -h ${HOSTNAME_OVERRIDE}"
+[ -n "${LISTENER_JOBS}" ] && \
+	LISTENER_OPTS+=" -j ${LISTENER_JOBS}"
 
 command=/usr/bin/listener.pl
 command_args="${LISTENER_OPTS}"


### PR DESCRIPTION
Found the one bug in my deployment.
This will set producer threads as intended when using a config. And this only happened because the naming convention doesn't make it clear which value applies to consumers and which to producers.