### PR TITLE
dev-db/postgresql/postgresql-{10.9,11.4}: don't delete libpg{port,comon}.a

### DIFF
--- a/dev-db/postgresql/postgresql-10.9.ebuild
+++ b/dev-db/postgresql/postgresql-10.9.ebuild
@@ -244,7 +244,11 @@ src_install() {
 	insinto /etc/postgresql-${SLOT}
 	newins src/bin/psql/psqlrc.sample psqlrc
 
-	use static-libs || find "${ED}" -name '*.a' -delete
+	# Don't delete libpg{port,common}.a (Bug #571046). They're always
+	# needed by extensions utilizing PGXS.
+	use static-libs || \
+		find "${ED}" -name '*.a' ! -name libpgport.a ! -name libpgcommon.a \
+			 -delete
 
 	local f bn
 	for f in $(find "${ED}/usr/$(get_libdir)/postgresql-${SLOT}/bin" \

--- a/dev-db/postgresql/postgresql-11.4.ebuild
+++ b/dev-db/postgresql/postgresql-11.4.ebuild
@@ -235,7 +235,11 @@ src_install() {
 	insinto /etc/postgresql-${SLOT}
 	newins src/bin/psql/psqlrc.sample psqlrc
 
-	use static-libs || find "${ED}" -name '*.a' -delete
+	# Don't delete libpg{port,common}.a (Bug #571046). They're always
+	# needed by extensions utilizing PGXS.
+	use static-libs || \
+		find "${ED}" -name '*.a' ! -name libpgport.a ! -name libpgcommon.a \
+			 -delete
 
 	local f bn
 	for f in $(find "${ED}/usr/$(get_libdir)/postgresql-${SLOT}/bin" \


### PR DESCRIPTION
> (Bug #571046)

Lifted from gentoos portage build dirs.
This apparently blocks efforts on the shards.

Ref: #279