### PR TITLE
bagger-tools-0.3: missing deps

### DIFF
--- a/app-admin/bagger-tools/bagger-tools-0.3.ebuild
+++ b/app-admin/bagger-tools/bagger-tools-0.3.ebuild
@@ -27,10 +27,12 @@ DEPEND="
 	dev-perl/DateTime
 	dev-perl/DateTime-Format-Strptime
 	dev-perl/DateTimeX-Easy
+	dev-perl/JSON
 	dev-perl/Module-Build
 	dev-perl/Parallel-ForkManager
 	dev-perl/Term-ProgressBar
 	dev-perl/Digest-SHA1
+	virtual/perl-Sys-Syslog
 "
 
 RDEPEND="${DEPEND}


### PR DESCRIPTION
Turns out bagger-tools only install by accident on most of our systems.

ref: https://github.com/adjust/infrastructure/issues/5705