### PR TITLE
Pgtelemetry bump

### DIFF
--- a/dev-db/pgtelemetry/pgtelemetry-1.0.0.ebuild
+++ b/dev-db/pgtelemetry/pgtelemetry-1.0.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=6
 
-POSTGRES_COMPAT=( 9.6 10 )
+POSTGRES_COMPAT=( 9.6 10 11 12)
 
 inherit postgres-multi
 

--- a/dev-db/pgtelemetry/pgtelemetry-1.0.0.ebuild
+++ b/dev-db/pgtelemetry/pgtelemetry-1.0.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=6
 
-POSTGRES_COMPAT=( 9.6 10 11 12)
+POSTGRES_COMPAT=( 9.6 10 11 12 )
 
 inherit postgres-multi
 


### PR DESCRIPTION
pgtelemetry is running on esh-shards, so it's fine with postgres 12.

To make the package installable again without pulling in postgres-10, I've made this little PR.