### PR TITLE
fix statsd_exporter socket permissions

### DIFF
--- a/app-metrics/statsd_exporter/files/statsd_exporter-initd
+++ b/app-metrics/statsd_exporter/files/statsd_exporter-initd
@@ -10,8 +10,8 @@ UDP_PORT="${UDP_PORT:-9125}"
 UNIXSOCKET="${UNIXSOCKET:-\"\"}"
 
 command=/usr/bin/statsd_exporter
-command_args="--web.listen-address=:${WEB_PORT} --statsd.listen-udp=:${UDP_PORT} --statsd.listen-unixgram=${UNIXSOCKET}"
-command_user="${command_user:-statsd_exporter:statsd_exporter}"
+command_args="--web.listen-address=:${WEB_PORT} --statsd.listen-udp=:${UDP_PORT} --statsd.listen-unixgram=${UNIXSOCKET} --statsd.unixsocket-mode=775"
+command_user="${command_user:-statsd_exporter:unbotify}"
 command_background=yes
 error_log="/var/log/statsd_exporter/error.log"
 


### PR DESCRIPTION
`statsd_exporter` socket file is owned by `statsd_exporter:statsd_exporter` with default 755 perms. To make it writable by `observation_predictor` I change it's group and perms to 775.