### PR TITLE
app-metrics/statsd_exporter: r1 for init fixes

### DIFF
--- a/app-metrics/statsd_exporter/files/statsd_exporter.confd-r1
+++ b/app-metrics/statsd_exporter/files/statsd_exporter.confd-r1
@@ -1,0 +1,5 @@
+# config file for /etc/init.d/statsd_exporter
+
+WEB_PORT=9102
+UDP_PORT=9125
+UNIXSOCKET="\"\""

--- a/app-metrics/statsd_exporter/files/statsd_exporter.initd-r1
+++ b/app-metrics/statsd_exporter/files/statsd_exporter.initd-r1
@@ -1,0 +1,22 @@
+#!/sbin/openrc-run
+# Copyright 1999-2020 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+description="Prometheus StatsD Exporter"
+
+WEB_PORT="${WEB_PORT:-9102}"
+UDP_PORT="${UDP_PORT:-9125}"
+UNIXSOCKET="${UNIXSOCKET:-\"\"}"
+
+command=/usr/bin/statsd_exporter
+command_args="--web.listen-address=:${WEB_PORT} --statsd.listen-udp=:${UDP_PORT} --statsd.listen-unixgram=${UNIXSOCKET} ${command_args_extra}"
+command_user="${command_user:-statsd_exporter:statsd_exporter}"
+command_background=yes
+error_log="/var/log/statsd_exporter/error.log"
+
+pidfile="/run/${RC_SVCNAME}.pid"
+
+depend() {
+	need net
+}

--- a/app-metrics/statsd_exporter/statsd_exporter-0.14.1-r1.ebuild
+++ b/app-metrics/statsd_exporter/statsd_exporter-0.14.1-r1.ebuild
@@ -1,0 +1,31 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit golang-base golang-vcs golang-build user
+
+DESCRIPTION="statsd_exporter receives StatsD metrics and exports them as Prometheus metrics"
+HOMEPAGE="https://prometheus.io"
+EGO_PN="github.com/prometheus/${PN}"
+
+LICENSE="Apache-2.0"
+SLOT="0"
+KEYWORDS="~amd64"
+IUSE=""
+
+DEPEND=">=dev-lang/go-1.5"
+RDEPEND="${DEPEND}"
+
+pkg_setup() {
+	enewgroup statsd_exporter
+	enewuser statsd_exporter -1 -1 -1 statsd_exporter
+}
+
+src_install() {
+	dobin statsd_exporter
+	newinitd "${FILESDIR}/${PN}.initd-r1" "${PN}"
+	newconfd "${FILESDIR}/${PN}.confd-r1" "${PN}"
+	diropts -o statsd_exporter -g statsd_exporter -m 0750
+	keepdir /var/log/statsd_exporter
+}


### PR DESCRIPTION
Renames files to follow a more standard format
Adds 'command_args_extra' to default init commands
Fixes oversight in confd to follow the default disabling value in init script