### PR TITLE
dev-db/pgbackrest: add spooler directory for async-archiving

### DIFF
--- a/dev-db/pgbackrest/pgbackrest-2.26.ebuild
+++ b/dev-db/pgbackrest/pgbackrest-2.26.ebuild
@@ -35,6 +35,8 @@ src_install()
 	# user postgres should exist implicitly by dev-db/postgresql
 	diropts -m 0775 -g postgres
 	keepdir /var/log/"${PN}"
+	# async wal archiving requires a spooler directory
+	keepdir /var/spool/"{PN}"
 
 	insinto /etc/logrotate.d
 	newins "${FILESDIR}/${PN}.logrotate" ${PN}


### PR DESCRIPTION
Without this directory, archiving asynchronously does not work. Since it's only a list of "okay" files with no size, it practically lives on pagecache.
Found out the hard way when working with cephfs and huge wal throughput.