### PR TITLE
sys-cluster/mesos: drop REQUIRED_USE.

### DIFF
--- a/sys-cluster/mesos/mesos-1.10.0.ebuild
+++ b/sys-cluster/mesos/mesos-1.10.0.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -38,8 +38,6 @@ REQUIRED_USE="${PYTHON_REQUIRED_USE}"
 DOCS=( LICENSE README.md NOTICE )
 
 RESTRICT="test"
-
-REQUIRED_USE="^^ ( master agent )"
 
 pkg_setup() {
 	python-single-r1_pkg_setup


### PR DESCRIPTION
Disable this constraint as we want to install both the agent and the master on some servers.