### PR TITLE
sys-cluster: fix a typo in the variable name.

### DIFF
--- a/sys-cluster/chronos-bin/files/chronos.initd
+++ b/sys-cluster/chronos-bin/files/chronos.initd
@@ -9,7 +9,7 @@ command_args="${JVM_OPTS} -cp ${CHRONOS_JAR} ${CHRONOS_MAIN} ${CHRONOS_ARGS}"
 command_background="true"
 start_stop_daemon_args="--user ${CHRONOS_USER} --group ${CHRONOS_GROUP}"
 pidfile="/var/run/${RC_SVCNAME}.pid"
-stdout_log="${CHRONOS_LOG_FILE}"
+output_log="${CHRONOS_LOG_FILE}"
 error_log="${CHRONOS_LOG_FILE}"
 
 depend() {

--- a/sys-cluster/mesos/files/mesos-agent.initd
+++ b/sys-cluster/mesos/files/mesos-agent.initd
@@ -9,7 +9,7 @@ command_args="${MESOS_AGENT_ARGS}"
 command_background="true"
 start_stop_daemon_args="--user ${MESOS_AGENT_USER} --group ${MESOS_AGENT_GROUP}"
 pidfile="/var/run/${RC_SVCNAME}.pid"
-stdout_log="${MESOS_AGENT_LOG_FILE}"
+output_log="${MESOS_AGENT_LOG_FILE}"
 error_log="${MESOS_AGENT_LOG_FILE}"
 
 depend() {

--- a/sys-cluster/mesos/files/mesos-master.initd
+++ b/sys-cluster/mesos/files/mesos-master.initd
@@ -9,7 +9,7 @@ command_args="${MESOS_MASTER_ARGS}"
 command_background="true"
 start_stop_daemon_args="--user ${MESOS_MASTER_USER} --group ${MESOS_MASTER_GROUP}"
 pidfile="/var/run/${RC_SVCNAME}.pid"
-stdout_log="${MESOS_MASTER_LOG_FILE}"
+output_log="${MESOS_MASTER_LOG_FILE}"
 error_log="${MESOS_MASTER_LOG_FILE}"
 
 depend() {

--- a/sys-cluster/spark-bin/files/spark-history.initd
+++ b/sys-cluster/spark-bin/files/spark-history.initd
@@ -12,7 +12,7 @@ command_args="${SPARK_HISTORY_ARGS} ${SPARK_HISTORY_CLASS}"
 command_background="true"
 start_stop_daemon_args="--user ${SPARK_HISTORY_USER} --group ${SPARK_HISTORY_GROUP}"
 pidfile="/var/run/${RC_SVCNAME}.pid"
-stdout_log="${SPARK_HISTORY_LOG_FILE}"
+output_log="${SPARK_HISTORY_LOG_FILE}"
 error_log="${SPARK_HISTORY_LOG_FILE}"
 
 depend() {

--- a/sys-cluster/spark-bin/files/spark-mcd.initd
+++ b/sys-cluster/spark-bin/files/spark-mcd.initd
@@ -12,7 +12,7 @@ command_args="${SPARK_MCD_CLASS} ${SPARK_MCD_ARGS}"
 command_background="true"
 start_stop_daemon_args="--user ${SPARK_MCD_USER} --group ${SPARK_MCD_GROUP}"
 pidfile="/var/run/${RC_SVCNAME}.pid"
-stdout_log="${SPARK_MCD_LOG_FILE}"
+output_log="${SPARK_MCD_LOG_FILE}"
 error_log="${SPARK_MCD_LOG_FILE}"
 
 depend() {


### PR DESCRIPTION
The correct variable name is output_log and not stdout_log.

Excerpt from man openrc-run:
```
output_log: This is the path to a file or named pipe where the standard
output from the service will be redirected.
```
I noticed the typo whilst rewriting an init script.

Signed-off-by: Patrice Clement <patrice.clement@adjust.com>