### PR TITLE
dev-libs/apache-arrow: add cmakeargs for compression types

### DIFF
--- a/dev-libs/apache-arrow/apache-arrow-0.17.1-r1.ebuild
+++ b/dev-libs/apache-arrow/apache-arrow-0.17.1-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -6,11 +6,13 @@ EAPI=7
 inherit cmake-utils
 
 DESCRIPTION="Apache Arrow and Parquet libraries"
+HOMEPAGE="https://arrow.apache.org"
+SRC_URI="https://github.com/apache/arrow/archive/apache-arrow-${PV}.tar.gz"
+
 LICENSE="Apache-2.0"
 KEYWORDS="~amd64 ~x86"
-HOMEPAGE="https://arrow.apache.org/"
-SRC_URI="https://github.com/apache/arrow/archive/apache-arrow-${PV}.tar.gz"
 SLOT="0"
+
 DEPEND="dev-libs/boost
 	dev-libs/thrift
 	dev-libs/rapidjson
@@ -23,7 +25,9 @@ DEPEND="dev-libs/boost
 	app-arch/snappy
 	app-arch/brotli
 "
+
 RDEPEND="${DEPEND}"
+
 S="${WORKDIR}/arrow-apache-arrow-${PV}"
 
 CMAKE_BUILD_TYPE="release"
@@ -34,6 +38,11 @@ src_configure() {
 	local mycmakeargs=(
 		-DARROW_PARQUET=ON
 		-DARROW_JEMALLOC=OFF
+		-DARROW_WITH_BROTLI=ON
+		-DARROW_WITH_LZ4=ON
+		-DARROW_WITH_SNAPPY=ON
+		-DARROW_WITH_ZLIB=ON
+		-DARROW_WITH_ZSTD=ON
 	)
 
 	cmake-utils_src_configure


### PR DESCRIPTION
Initial fixes to apache-arrow ebuild.

Now passing some additional args to cmake for multiple compression types.

This _should_ be part of fixes for [https://github.com/adjust/infrastructure/issues/10897](url)