### PR TITLE
dev-libs/apache-arrow: fix rapidjson dep + cmake inherit

### DIFF
--- a/dev-libs/apache-arrow/apache-arrow-0.17.1-r2.ebuild
+++ b/dev-libs/apache-arrow/apache-arrow-0.17.1-r2.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-inherit cmake-utils
+inherit cmake
 
 DESCRIPTION="Apache Arrow and Parquet libraries"
 HOMEPAGE="https://arrow.apache.org"
@@ -15,7 +15,10 @@ SLOT="0"
 
 DEPEND="dev-libs/boost
 	dev-libs/thrift
-	dev-libs/rapidjson
+	|| (
+		dev-libs/rapidjson
+		sys-cluster/mesos
+	)
 	dev-libs/double-conversion
 	dev-libs/jemalloc
 	dev-cpp/gflags
@@ -45,5 +48,5 @@ src_configure() {
 		-DARROW_WITH_ZSTD=ON
 	)
 
-	cmake-utils_src_configure
+	cmake_src_configure
 }


### PR DESCRIPTION
dev-libs/apache-arrow has a DEPEND on dev-libs/rapidjson which can be satisfied with header files provided by sys-cluster/mesos (which is currently in use on some servers), so make either package satisfy the requirement from dev-libs/apache-arrow.

repoman complains about cmake-utils eclass being deprecated in favour of cmake eclass, so I have migrated that for now. Tested on local ~amd64 Gentoo Linux machine and is building fine.

Fix for #11262