### PR TITLE
dev-perl/Ruby-VersionManager: inherit vcs-snapshot eclass.

### DIFF
--- a/dev-perl/Ruby-VersionManager/Ruby-VersionManager-0.1.ebuild
+++ b/dev-perl/Ruby-VersionManager/Ruby-VersionManager-0.1.ebuild
@@ -3,11 +3,11 @@
 
 EAPI=7
 
-inherit perl-module
+inherit perl-module vcs-snapshot
 
 DESCRIPTION="Module to manage ruby versions in non-interactive environments"
 HOMEPAGE="https://github.com/adjust/p5-Ruby-VersionManager"
-SRC_URI="https://github.com/adjust/p5-Ruby-VersionManager/archive/refs/tags/v${PVR}.tar.gz -> ${PN}-${PV}.tar.gz"
+SRC_URI="https://github.com/adjust/p5-Ruby-VersionManager/archive/refs/tags/v${PVR}.tar.gz -> ${P}.tar.gz"
 
 KEYWORDS="~amd64"
 LICENSE="MIT"
@@ -19,18 +19,10 @@ IUSE=""
 DEPEND="
 	dev-perl/Moo
 	dev-perl/YAML
-	dev-perl/libwww-perl
-"
+	dev-perl/libwww-perl"
 
 RDEPEND="
-	${DEPEND}
-"
-
-src_unpack() {
-	default
-
-        mv "${WORKDIR}"/p5-${PN}-${PV} "${WORKDIR}"/${PN}-${PV}
-}
+	${DEPEND}"
 
 src_install() {
 	mytargets="install"


### PR DESCRIPTION
If you find yourself tinkering with the directory name in the `src_unpack` phase, simply inherit the `vcs-snapshot` eclass and enjoy life instead.

@xmhd @varilci 