### PR TITLE
sys-cluster/mesos: fix maven dep + remove openjdk-bin dep

### DIFF
--- a/sys-cluster/mesos/mesos-1.10.0.ebuild
+++ b/sys-cluster/mesos/mesos-1.10.0.ebuild
@@ -22,8 +22,7 @@ RDEPEND="
 DEPEND="
 	${PYTHON_DEPS}
 	>=virtual/jdk-1.8
-	dev-java/maven-bin:3.6
-	dev-java/openjdk-bin
+	dev-java/maven-bin:3.8
 	dev-libs/cyrus-sasl
 	dev-vcs/subversion
 	dev-python/six


### PR DESCRIPTION
fix some deps to satisfy qa

note: mesos package seems to fail currently (even before these changes - appears to require some SANDBOX_WRITE="foo" tweaks), will investigate further after this is merged.