### PR TITLE
dev-db/bagger-exports: tweak required schaufel ver

### DIFF
--- a/dev-db/bagger-exports/bagger-exports-0.0.8.ebuild
+++ b/dev-db/bagger-exports/bagger-exports-0.0.8.ebuild
@@ -29,7 +29,7 @@ RDEPEND="
 	${DEPEND}
 	${POSTGRES_DEP}
 	schaufel? (
-		>=app-admin/schaufel-0.9
+		>=app-admin/schaufel-0.8
 	)
 	>=dev-lang/perl-5.26
 "


### PR DESCRIPTION
as per title.

@65278 is this ok? I see bagger-exports-0.0.7 requires schaufel-0.7, and so on for other vers. schaufel-0.9 doesn't exist now and is leaving a qa error.