### PR TITLE
virtual/adjust-infrastructure: small tweaks

### DIFF
--- a/virtual/adjust-infrastructure/adjust-infrastructure-0.2.ebuild
+++ b/virtual/adjust-infrastructure/adjust-infrastructure-0.2.ebuild
@@ -13,7 +13,12 @@ IUSE=""
 
 RDEPEND="
 	|| (
-		app-admin/rex
+		app-admin/rex (
+			dev-perl/Rex-Hook-File-Diff
+			dev-perl/Rex-Hook-File-Impostor
+			dev-perl/Rex-Interface-Shell-Idrac4
+			dev-perl/Rex-Interface-Shell-Ilo
+		)
 		app-admin/trex
 	)
 	dev-perl/autovivification
@@ -27,10 +32,6 @@ RDEPEND="
 	dev-perl/Net-CIDR-Lite
 	dev-perl/Number-Bytes-Human
 	dev-perl/Path-Tiny
-	dev-perl/Rex-Hook-File-Diff
-	dev-perl/Rex-Hook-File-Impostor
-	dev-perl/Rex-Interface-Shell-Idrac4
-	dev-perl/Rex-Interface-Shell-Ilo
 	dev-perl/Search-Elasticsearch
 	dev-perl/Search-Elasticsearch-Client-2_0
 	dev-perl/String-ShellQuote

--- a/virtual/adjust-infrastructure/adjust-infrastructure-0.2.ebuild
+++ b/virtual/adjust-infrastructure/adjust-infrastructure-0.2.ebuild
@@ -13,13 +13,13 @@ IUSE=""
 
 RDEPEND="
 	|| (
+		app-admin/trex
 		app-admin/rex (
 			dev-perl/Rex-Hook-File-Diff
 			dev-perl/Rex-Hook-File-Impostor
 			dev-perl/Rex-Interface-Shell-Idrac4
 			dev-perl/Rex-Interface-Shell-Ilo
 		)
-		app-admin/trex
 	)
 	dev-perl/autovivification
 	dev-perl/Data-Printer


### PR DESCRIPTION
Small tweaks for the ebuild as a whole.

e.g. only depend on dev-perl/Rex-foo-bar if app-admin/rex is in use.

Default to app-admin/trex.