### PR TITLE
dev-db/postgresql: add hugelwlock useflag

### DIFF
--- a/dev-db/postgresql/files/lock_partitions.patch
+++ b/dev-db/postgresql/files/lock_partitions.patch
@@ -1,0 +1,17 @@
+Index: postgresql-12.6/src/include/storage/lwlock.h
+===================================================================
+--- postgresql-12.6.orig/src/include/storage/lwlock.h
++++ postgresql-12.6/src/include/storage/lwlock.h
+@@ -110,10 +110,10 @@ extern PGDLLIMPORT int NamedLWLockTranch
+  */
+ 
+ /* Number of partitions of the shared buffer mapping hashtable */
+-#define NUM_BUFFER_PARTITIONS  128
++#define NUM_BUFFER_PARTITIONS  512
+ 
+ /* Number of partitions the shared lock tables are divided into */
+-#define LOG2_NUM_LOCK_PARTITIONS  4
++#define LOG2_NUM_LOCK_PARTITIONS  9
+ #define NUM_LOCK_PARTITIONS  (1 << LOG2_NUM_LOCK_PARTITIONS)
+ 
+ /* Number of partitions the shared predicate lock tables are divided into */

--- a/dev-db/postgresql/metadata.xml
+++ b/dev-db/postgresql/metadata.xml
@@ -13,6 +13,10 @@
 		<flag name="cassert">
 			Enable assertion checks (for debugging)
 		</flag>
+		<flag name="hugelwlock">
+			Increase number of lwlock and buffer partitions. You do not
+			need this if you do not know what this is.
+		</flag>
 		<flag name="llvm">
 			Add support for llvm JIT engine
 		</flag>

--- a/dev-db/postgresql/postgresql-12.7.ebuild
+++ b/dev-db/postgresql/postgresql-12.7.ebuild
@@ -20,9 +20,9 @@ LICENSE="POSTGRESQL GPL-2"
 DESCRIPTION="PostgreSQL RDBMS"
 HOMEPAGE="https://www.postgresql.org/"
 
-IUSE="bagger cassert debug doc icu kerberos kernel_linux ldap llvm nls pam
-	  perl python +readline selinux +server systemd ssl static-libs tcl
-	  +threads uuid xml zlib"
+IUSE="bagger cassert debug doc hugelwlock icu kerberos kernel_linux ldap
+	  llvm nls pam perl python +readline selinux +server systemd ssl static-libs
+	  tcl +threads uuid xml zlib"
 
 REQUIRED_USE="python? ( ${PYTHON_REQUIRED_USE} )"
 
@@ -112,6 +112,10 @@ src_prepare() {
 	# bagger
 	if use bagger ; then
 		eapply "${FILESDIR}"/${PN}-10.0-index.patch
+	fi
+
+	if use hugelwlock ; then
+		eapply "${FILESDIR}"/lock_partitions.patch
 	fi
 
 	eapply_user

--- a/dev-db/postgresql/postgresql-13.3.ebuild
+++ b/dev-db/postgresql/postgresql-13.3.ebuild
@@ -20,9 +20,9 @@ LICENSE="POSTGRESQL GPL-2"
 DESCRIPTION="PostgreSQL RDBMS"
 HOMEPAGE="https://www.postgresql.org/"
 
-IUSE="bagger cassert debug doc icu kerberos kernel_linux ldap llvm nls pam
-	  perl python +readline selinux +server systemd ssl static-libs tcl
-	  +threads uuid xml zlib"
+IUSE="bagger cassert debug doc hugelwlock icu kerberos kernel_linux ldap
+	  llvm nls pam perl python +readline selinux +server systemd ssl static-libs
+	  tcl +threads uuid xml zlib"
 
 REQUIRED_USE="python? ( ${PYTHON_REQUIRED_USE} )"
 
@@ -112,6 +112,10 @@ src_prepare() {
 	# bagger
 	if use bagger ; then
 		eapply "${FILESDIR}"/${PN}-10.0-index.patch
+	fi
+
+	if use hugelwlock ; then
+		eapply "${FILESDIR}"/lock_partitions.patch
 	fi
 
 	eapply_user


### PR DESCRIPTION
Work in progress: Finding the right tuning to avoid buffer mapping locks on seriously huge postgres instances.