### PR TITLE
dev-db/postgresql: delete pg-legacytimestamp in use_enable.

### DIFF
--- a/dev-db/postgresql/postgresql-9.6.22.ebuild
+++ b/dev-db/postgresql/postgresql-9.6.22.ebuild
@@ -147,7 +147,7 @@ src_configure() {
 		--with-system-tzdata="${PO}/usr/share/zoneinfo" \
 		$(use_enable !alpha spinlocks) \
 		$(use_enable cassert) \
-		$(use_enable !pg-legacytimestamp integer-datetimes) \
+		$(use_enable integer-datetimes) \
 		$(use_enable debug) \
 		$(use_enable threads thread-safety) \
 		$(use_with kerberos gssapi) \

--- a/dev-db/postgresql/postgresql-9.6.22.ebuild
+++ b/dev-db/postgresql/postgresql-9.6.22.ebuild
@@ -147,7 +147,6 @@ src_configure() {
 		--with-system-tzdata="${PO}/usr/share/zoneinfo" \
 		$(use_enable !alpha spinlocks) \
 		$(use_enable cassert) \
-		$(use_enable integer-datetimes) \
 		$(use_enable debug) \
 		$(use_enable threads thread-safety) \
 		$(use_with kerberos gssapi) \


### PR DESCRIPTION
Closes: https://github.com/adjust/gentoo-overlay/issues/647
Package-Manager: Portage-3.0.20, Repoman-3.0.3