### PR TITLE
sys-kernel/genkernel: implement logic for fetching squashfs image via network

### DIFF
--- a/sys-kernel/genkernel/files/genkernel-4.2.3-fetch_sqfs.patch
+++ b/sys-kernel/genkernel/files/genkernel-4.2.3-fetch_sqfs.patch
@@ -1,5 +1,5 @@
 diff --git a/defaults/linuxrc b/defaults/linuxrc
-index 6ede740..a485358 100644
+index 6ede740..1e36719 100644
 --- a/defaults/linuxrc
 +++ b/defaults/linuxrc
 @@ -179,6 +179,10 @@ do
@@ -7,25 +7,29 @@ index 6ede740..a485358 100644
  			NFSROOT=${x#*=}
  		;;
 +		fetch_sqfs=*)
-+			USE_SQFS_FETCH=1
++			USE_FETCH_SQFS=1
 +			SQFS_URI=${x#*=}
 +		;;
  		# iSCSI
  		iscsi_initiatorname=*)
  			ISCSI_INITIATORNAME=${x#*=}
-@@ -615,6 +619,19 @@ then
+@@ -615,6 +619,23 @@ then
  	start_iscsi
  fi
  
-+# optionally fetch a squashfs image from the network
-+if [ "${USE_SQFS_FETCH}" = '1' ]
++# optionally fetch a squashfs image via network
++if [ "${USE_FETCH_SQFS}" = '1' ]
 +then
 +	start_network
 +
-+	good_msg "Fetching $SQFS_URI"
-+
 +	# CWD is /newroot
-+	wget -O - $SQFS_URI > ${LOOP} && good_msg "Written to ${LOOP}"
++
++	sqfs_img=$(basename $SQFS_URI)
++	good_msg "Fetching $SQFS_URI ..."
++	wget -O - $SQFS_URI > "/newroot/$sqfs_img" && good_msg "$SQFS_URI fetch complete ..."
++
++	good_msg "Writting $sqfs_uri to ${LOOP} ..."
++	cat "/newroot/$sqfs_img" > ${LOOP} && good_msg "Write $sqfs_img to ${LOOP} complete ..."
 +
 +	unset SQFS_URI
 +fi
@@ -33,13 +37,13 @@ index 6ede740..a485358 100644
  # Loop file already exists on fs, assume no mount needed,
  # This allows for squashfs in initrd, which can be used for (i)PXE booting
  if [ -e "${LOOP}" ]
-@@ -634,7 +651,11 @@ setup_keymap
+@@ -634,7 +655,11 @@ setup_keymap
  
  if [ "${USE_SSH}" = '1' ]
  then
 -	start_network
-+	# network is already started if USE_SQFS_FETCH is true
-+	if [ "${USE_SQFS_FETCH}" != '1' ]
++	# network is already started if USE_FETCH_SQFS is true
++	if [ "${USE_FETCH_SQFS}" != '1' ]
 +	then
 +		start_network
 +	fi

--- a/sys-kernel/genkernel/files/genkernel-4.2.3-fetch_sqfs.patch
+++ b/sys-kernel/genkernel/files/genkernel-4.2.3-fetch_sqfs.patch
@@ -1,3 +1,16 @@
+diff --git a/defaults/linuxrc b/defaults/linuxrc
+index aed7cba..38b65ca 100644
+--- a/defaults/linuxrc
++++ b/defaults/linuxrc
+@@ -628,7 +628,7 @@ then
+ 
+ 	sqfs_img=$(basename $SQFS_URI)
+ 	good_msg "Fetching $SQFS_URI ..."
+-	wget -O - $SQFS_URI > "/newroot/$sqfs_img" && good_msg "$SQFS_URI fetch complete ..."
++	wget -T 60 --show-progress -O - $SQFS_URI > "/newroot/$sqfs_img" && good_msg "$SQFS_URI fetch complete ..."
+ 
+ 	good_msg "Writting $sqfs_uri to ${LOOP} ..."
+ 	cat "/newroot/$sqfs_img" > ${LOOP} && good_msg "Write $sqfs_img to ${LOOP} complete ..."
 diff --git a/genkernel-4.2.3-fetch_sqfs.patch b/genkernel-4.2.3-fetch_sqfs.patch
 index fc098f4..e69de29 100644
 --- a/genkernel-4.2.3-fetch_sqfs.patch

--- a/sys-kernel/genkernel/files/genkernel-4.2.3-fetch_sqfs.patch
+++ b/sys-kernel/genkernel/files/genkernel-4.2.3-fetch_sqfs.patch
@@ -1,67 +1,72 @@
-diff --git a/defaults/linuxrc b/defaults/linuxrc
-index 6ede740..1e36719 100644
---- a/defaults/linuxrc
-+++ b/defaults/linuxrc
-@@ -179,6 +179,10 @@ do
- 		nfsroot=*)
- 			NFSROOT=${x#*=}
- 		;;
-+		fetch_sqfs=*)
-+			USE_FETCH_SQFS=1
-+			SQFS_URI=${x#*=}
-+		;;
- 		# iSCSI
- 		iscsi_initiatorname=*)
- 			ISCSI_INITIATORNAME=${x#*=}
-@@ -615,6 +619,23 @@ then
- 	start_iscsi
- fi
- 
-+# optionally fetch a squashfs image via network
-+if [ "${USE_FETCH_SQFS}" = '1' ]
-+then
-+	start_network
-+
-+	# CWD is /newroot
-+
-+	sqfs_img=$(basename $SQFS_URI)
-+	good_msg "Fetching $SQFS_URI ..."
-+	wget -O - $SQFS_URI > "/newroot/$sqfs_img" && good_msg "$SQFS_URI fetch complete ..."
-+
-+	good_msg "Writting $sqfs_uri to ${LOOP} ..."
-+	cat "/newroot/$sqfs_img" > ${LOOP} && good_msg "Write $sqfs_img to ${LOOP} complete ..."
-+
-+	unset SQFS_URI
-+fi
-+
- # Loop file already exists on fs, assume no mount needed,
- # This allows for squashfs in initrd, which can be used for (i)PXE booting
- if [ -e "${LOOP}" ]
-@@ -634,7 +655,11 @@ setup_keymap
- 
- if [ "${USE_SSH}" = '1' ]
- then
--	start_network
-+	# network is already started if USE_FETCH_SQFS is true
-+	if [ "${USE_FETCH_SQFS}" != '1' ]
-+	then
-+		start_network
-+	fi
- 	start_sshd
- fi
- 
-diff --git a/doc/genkernel.8.txt b/doc/genkernel.8.txt
-index 273f9c1..b7d3493 100644
---- a/doc/genkernel.8.txt
-+++ b/doc/genkernel.8.txt
-@@ -819,6 +819,10 @@ when not set. This will allow remote user to provide answer through
-     location. Otherwise the location will be deduced from the DCHP
-     request (option root-path).
- 
-+*fetch_sqfs*=<...>::
-+    If present, the initrd will try to fetch a squashfs image
-+    from the given uri, e.g. fetch_sqfs=https://foo.bar/sqfs.image
-+
- *dolvm*::
-     Activate LVM volumes on bootup.
- 
+diff --git a/genkernel-4.2.3-fetch_sqfs.patch b/genkernel-4.2.3-fetch_sqfs.patch
+index fc098f4..e69de29 100644
+--- a/genkernel-4.2.3-fetch_sqfs.patch
++++ b/genkernel-4.2.3-fetch_sqfs.patch
+@@ -1,67 +0,0 @@
+-diff --git a/defaults/linuxrc b/defaults/linuxrc
+-index 6ede740..1e36719 100644
+---- a/defaults/linuxrc
+-+++ b/defaults/linuxrc
+-@@ -179,6 +179,10 @@ do
+- 		nfsroot=*)
+- 			NFSROOT=${x#*=}
+- 		;;
+-+		fetch_sqfs=*)
+-+			USE_FETCH_SQFS=1
+-+			SQFS_URI=${x#*=}
+-+		;;
+- 		# iSCSI
+- 		iscsi_initiatorname=*)
+- 			ISCSI_INITIATORNAME=${x#*=}
+-@@ -615,6 +619,23 @@ then
+- 	start_iscsi
+- fi
+- 
+-+# optionally fetch a squashfs image via network
+-+if [ "${USE_FETCH_SQFS}" = '1' ]
+-+then
+-+	start_network
+-+
+-+	# CWD is /newroot
+-+
+-+	sqfs_img=$(basename $SQFS_URI)
+-+	good_msg "Fetching $SQFS_URI ..."
+-+	wget -O - $SQFS_URI > "/newroot/$sqfs_img" && good_msg "$SQFS_URI fetch complete ..."
+-+
+-+	good_msg "Writting $sqfs_uri to ${LOOP} ..."
+-+	cat "/newroot/$sqfs_img" > ${LOOP} && good_msg "Write $sqfs_img to ${LOOP} complete ..."
+-+
+-+	unset SQFS_URI
+-+fi
+-+
+- # Loop file already exists on fs, assume no mount needed,
+- # This allows for squashfs in initrd, which can be used for (i)PXE booting
+- if [ -e "${LOOP}" ]
+-@@ -634,7 +655,11 @@ setup_keymap
+- 
+- if [ "${USE_SSH}" = '1' ]
+- then
+--	start_network
+-+	# network is already started if USE_FETCH_SQFS is true
+-+	if [ "${USE_FETCH_SQFS}" != '1' ]
+-+	then
+-+		start_network
+-+	fi
+- 	start_sshd
+- fi
+- 
+-diff --git a/doc/genkernel.8.txt b/doc/genkernel.8.txt
+-index 273f9c1..b7d3493 100644
+---- a/doc/genkernel.8.txt
+-+++ b/doc/genkernel.8.txt
+-@@ -819,6 +819,10 @@ when not set. This will allow remote user to provide answer through
+-     location. Otherwise the location will be deduced from the DCHP
+-     request (option root-path).
+- 
+-+*fetch_sqfs*=<...>::
+-+    If present, the initrd will try to fetch a squashfs image
+-+    from the given uri, e.g. fetch_sqfs=https://foo.bar/sqfs.image
+-+
+- *dolvm*::
+-     Activate LVM volumes on bootup.
+- 

--- a/sys-kernel/genkernel/files/genkernel-4.2.3-fetch_sqfs.patch
+++ b/sys-kernel/genkernel/files/genkernel-4.2.3-fetch_sqfs.patch
@@ -1,0 +1,63 @@
+diff --git a/defaults/linuxrc b/defaults/linuxrc
+index 6ede740..a485358 100644
+--- a/defaults/linuxrc
++++ b/defaults/linuxrc
+@@ -179,6 +179,10 @@ do
+ 		nfsroot=*)
+ 			NFSROOT=${x#*=}
+ 		;;
++		fetch_sqfs=*)
++			USE_SQFS_FETCH=1
++			SQFS_URI=${x#*=}
++		;;
+ 		# iSCSI
+ 		iscsi_initiatorname=*)
+ 			ISCSI_INITIATORNAME=${x#*=}
+@@ -615,6 +619,19 @@ then
+ 	start_iscsi
+ fi
+ 
++# optionally fetch a squashfs image from the network
++if [ "${USE_SQFS_FETCH}" = '1' ]
++then
++	start_network
++
++	good_msg "Fetching $SQFS_URI"
++
++	# CWD is /newroot
++	wget -O - $SQFS_URI > ${LOOP} && good_msg "Written to ${LOOP}"
++
++	unset SQFS_URI
++fi
++
+ # Loop file already exists on fs, assume no mount needed,
+ # This allows for squashfs in initrd, which can be used for (i)PXE booting
+ if [ -e "${LOOP}" ]
+@@ -634,7 +651,11 @@ setup_keymap
+ 
+ if [ "${USE_SSH}" = '1' ]
+ then
+-	start_network
++	# network is already started if USE_SQFS_FETCH is true
++	if [ "${USE_SQFS_FETCH}" != '1' ]
++	then
++		start_network
++	fi
+ 	start_sshd
+ fi
+ 
+diff --git a/doc/genkernel.8.txt b/doc/genkernel.8.txt
+index 273f9c1..b7d3493 100644
+--- a/doc/genkernel.8.txt
++++ b/doc/genkernel.8.txt
+@@ -819,6 +819,10 @@ when not set. This will allow remote user to provide answer through
+     location. Otherwise the location will be deduced from the DCHP
+     request (option root-path).
+ 
++*fetch_sqfs*=<...>::
++    If present, the initrd will try to fetch a squashfs image
++    from the given uri, e.g. fetch_sqfs=https://foo.bar/sqfs.image
++
+ *dolvm*::
+     Activate LVM volumes on bootup.
+ 

--- a/sys-kernel/genkernel/genkernel-4.2.3.ebuild
+++ b/sys-kernel/genkernel/genkernel-4.2.3.ebuild
@@ -127,6 +127,7 @@ fi
 
 PATCHES=(
 	"${FILESDIR}/genkernel-4.2.1-include-udev-rules.patch"
+	"${FILESDIR}/genkernel-4.2.3-fetch_sqfs.patch"
 )
 
 src_unpack() {


### PR DESCRIPTION
As per title.

Genkernel supports squashfs images embedded in the initramfs (as this was designed for liveCD's), however there is currently no logic for fetching an image via network.

This PR adds a new parameter 'fetch_sqfs=foo" to be passed which will provide a uri to fetch the squashfs image from. startup_network is handled if this parameter is used, and there is a conditional added to the startup_network code for USE_SSHD, so that we don't call start_network twice.