### PR TITLE
dev-python/jupyterhub: switch from oauth2 to oauthlib.

### DIFF
--- a/dev-python/jupyterhub/jupyterhub-1.1.0.ebuild
+++ b/dev-python/jupyterhub/jupyterhub-1.1.0.ebuild
@@ -30,7 +30,7 @@ RDEPEND="
 	dev-python/entrypoints[${PYTHON_USEDEP}]
 	dev-python/jinja[${PYTHON_USEDEP}]
 	dev-python/jupyter-telemetry[${PYTHON_USEDEP}]
-	dev-python/oauth2[${PYTHON_USEDEP}]
+	dev-python/oauthlib[${PYTHON_USEDEP}]
 	dev-python/pamela[${PYTHON_USEDEP}]
 	>=dev-python/prometheus_client-0.0.21[${PYTHON_USEDEP}]
 	dev-python/python-dateutil[${PYTHON_USEDEP}]


### PR DESCRIPTION
dev-python/oauth2 has been masked, see https://gitweb.gentoo.org/repo/gentoo.git/commit/?id=80bf8350bb3a4f9934957a73a3eb630cc591239d.

Switch to dev-python/oauthlib as suggested in the package.mask message.