### PR TITLE
adding supervisord_exporter ebuild

### DIFF
--- a/app-metrics/supervisord_exporter/files/supervisord_exporter
+++ b/app-metrics/supervisord_exporter/files/supervisord_exporter
@@ -1,0 +1,22 @@
+#!/sbin/openrc-run
+# Copyright 2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+name="${RC_SVCNAME}"
+description="Exports supervisord managed jobs cpu and memory usage metrics to prometheus exporter"
+command="/var/lib/node_exporter/${RC_SVCNAME}.py"
+command_user="node_exporter"
+pidfile="/run/${RC_SVCNAME}.pid"
+start_stop_daemon_args="-d /var/lib/node_exporter"
+command_background=true
+output_log="/var/lib/node_exporter/${RC_SVCNAME}.log"
+error_log="/var/lib/node_exporter/${RC_SVCNAME}.err"
+depend() {
+	after supervisord
+}
+start_pre() {
+    checkpath --directory --owner ${command_user}:${command_user} --mode 0775 \
+       /var/lib/node_exporter 
+    checkpath -f --owner ${command_user}:${command_user} --mode 0550 \
+       /var/lib/node_exporter/${RC_SVCNAME}.py
+}

--- a/app-metrics/supervisord_exporter/files/supervisord_exporter.py
+++ b/app-metrics/supervisord_exporter/files/supervisord_exporter.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+import subprocess
+import re
+from time import sleep
+import psutil
+
+def get_supervisord_jobs_metrics(jobs:dict):
+    metrics = jobs
+    for p in psutil.process_iter(['pid','cpu_percent','memory_percent']):
+        if str(p.info["pid"]) in jobs.keys():
+            metrics[str(p.info["pid"])]["cpu_usage"] = p.info["cpu_percent"]
+            metrics[str(p.info["pid"])]["mem_usage"] = p.info["memory_percent"]
+    return metrics
+
+def update_supervisord_jobs():
+    supervisord_jobs = subprocess.run(['sudo', '/usr/bin/supervisorctl','status all'], stdout = subprocess.PIPE)
+    raw_output = supervisord_jobs.stdout.decode('UTF-8').splitlines()
+    jobs = dict()
+    for i in range(len(raw_output)):
+        line = re.sub(' +',' ',raw_output[i])
+        elems = line.split(maxsplit=4)
+        if len(elems) == 5:
+            elems[3] = elems[3].replace(",","")
+            if elems[3].isdigit():
+                if elems[0].find(":") != -1:
+                    jobs[elems[3]] =  {
+                            "group":elems[0].split(":")[0],
+                            "name":elems[0].split(":")[1],
+                        }
+                else:
+                    jobs[elems[3]] =  {
+                            "name":elems[0].split(":")[0]
+                        }
+    return jobs
+
+def dump_job_metrics(jobs:dict,metric):
+    lines = []
+    if metric in ["cpu_usage","mem_usage"]:
+        for pid in jobs.keys():
+            if "group" in jobs[pid]:
+                lines.append(f'supervisord_job_{metric}{{group="{jobs[pid]["group"]}", name="{jobs[pid]["name"]}"}} {jobs[pid][metric]}\n')
+            else:
+                lines.append(f'supervisord_job_{metric}{{name="{jobs[pid]["name"]}"}} {jobs[pid][metric]}\n')
+    return lines
+
+while True:
+    count = 0
+    jobs = update_supervisord_jobs()
+    while count < 6:
+        metrics = get_supervisord_jobs_metrics(jobs)
+        f = open('supervisor.prom','w')
+        f.writelines(['# HELP supervisord_job_cpu_usage Percentage of cpu usage at the moment.\n','# TYPE supervisord_job_cpu_usage gauge\n'])
+        f.writelines(dump_job_metrics(metrics,'cpu_usage'))
+        f.writelines(['# HELP supervisord_job_mem_usage Percentage of mem usage at the moment.\n','# TYPE supervisord_job_mem_usage gauge\n'])
+        f.writelines(dump_job_metrics(metrics,'mem_usage'))
+        f.close()
+        count = count + 1
+        sleep(10)
+

--- a/app-metrics/supervisord_exporter/metadata.xml
+++ b/app-metrics/supervisord_exporter/metadata.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+        <maintainer type="person">
+                <email>ops@adjust.com</email>
+                <name>Adjust Ops</name>
+        </maintainer>
+</pkgmetadata>

--- a/app-metrics/supervisord_exporter/supervisord_exporter-0.0.1.ebuild
+++ b/app-metrics/supervisord_exporter/supervisord_exporter-0.0.1.ebuild
@@ -1,0 +1,29 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+PYTHON_COMPAT=( python3_{8..9} )
+HOMEPAGE="https://github.com/adjust"
+DESCRIPTION="Monitor cpu and memory usage by supervisord jobs for Prometheus node_exporter"
+
+KEYWORDS="~amd64"
+LICENSE="Apache-2.0"
+SLOT="0"
+
+IUSE=""
+
+RDEPEND="
+	app-metrics/node_exporter
+	dev-python/psutil
+"
+S=${FILESDIR}
+src_install() {
+	newinitd "${FILESDIR}"/${PN} ${PN}
+	insinto /var/lib/node_exporter
+	newins "${FILESDIR}"/${PN}.py "${PN}.py"
+	fowners node_exporter:node_exporter /var/lib/node_exporter
+	fowners node_exporter:node_exporter /var/lib/node_exporter/${PN}.py
+	fperms 0775 /var/lib/node_exporter
+	fperms 0550 /var/lib/node_exporter/${PN}.py
+}


### PR DESCRIPTION
This package depend on node_exporter
It will dump a prometheus metric file about the running supervisord jobs cpu and memory consumption each 10seconds in /var/lib/node_exporter. Then, the node exporter will parse that file each for each scrape.