### PR TITLE
acct-user/github_runner: Add home to user

### DIFF
--- a/acct-user/github_runner/github_runner-0.ebuild
+++ b/acct-user/github_runner/github_runner-0.ebuild
@@ -7,5 +7,6 @@ inherit acct-user
 
 ACCT_USER_ID=-1
 ACCT_USER_GROUPS=( ${PN} )
+ACCT_USER_HOME="/var/lib/${PN}"
 
 acct-user_add_deps


### PR DESCRIPTION
Some applications (like vagrant) require a home directory to be
available.
@artemyevav @xmhd 