### PR TITLE
supervisord_exporter: bug fix

### DIFF
--- a/app-metrics/supervisord_exporter/files/supervisord_exporter.py
+++ b/app-metrics/supervisord_exporter/files/supervisord_exporter.py
@@ -37,6 +37,8 @@ def dump_job_metrics(jobs:dict,metric):
     lines = []
     if metric in ["cpu_usage","mem_usage"]:
         for pid in jobs.keys():
+            if metric not in jobs[pid]:
+                continue
             if "group" in jobs[pid]:
                 lines.append(f'supervisord_job_{metric}{{group="{jobs[pid]["group"]}", name="{jobs[pid]["name"]}"}} {jobs[pid][metric]}\n')
             else:


### PR DESCRIPTION
when a supervisord job is destroyed and restarted it will be affected another pid. In the 60 seconds window until supervisord jobs list is updated, the metric dump will try to access elements that doesn't exist anymore in the list. I added an additional check to make sure that the keys exist before trying to access.