### PR TITLE
Add support for nocairo carbonapi build

### DIFF
--- a/app-metrics/carbonapi/carbonapi-0.15.4.ebuild
+++ b/app-metrics/carbonapi/carbonapi-0.15.4.ebuild
@@ -13,7 +13,7 @@ DESCRIPTION="Implementation of graphite API (graphite-web) in golang"
 HOMEPAGE="https://github.com/go-graphite/carbonapi"
 LICENSE="MIT"
 SLOT="0"
-IUSE=""
+IUSE="nocairo"
 
 RDEPEND="
 	acct-group/carbon
@@ -24,7 +24,8 @@ RDEPEND="
 
 src_compile() {
 	export BUILD="${PV}"
-	emake
+	use nocairo || emake
+	use nocairo && emake nocairo
 }
 
 src_install() {


### PR DESCRIPTION
Carbonapi offers a graphical support for generating graphs based on cairo lib. We do not use this as we interface carbon api all the time with grafana instead. 
This use flag will allow us to build carbonapi without cairo support from portage layer.
ref: https://github.com/go-graphite/carbonapi/blob/main/BUILD.md#build-instructions