### PR TITLE
Schaufel libconfig parser bug

### DIFF
--- a/app-admin/schaufel/schaufel-9999.ebuild
+++ b/app-admin/schaufel/schaufel-9999.ebuild
@@ -27,7 +27,7 @@ RDEPEND="
 	dev-libs/hiredis
 	dev-db/postgresql
 	dev-libs/json-c
-	dev-libs/libconfig
+	>=dev-libs/libconfig-1.7
 	doc? (
 		sys-apps/groff
 		app-text/ghostscript-gpl


### PR DESCRIPTION
Libconfig 1.5 has a bug concerning its grammar (no comma before empty element in a list). 
To force all servers to bump libconfig on schaufel build, I've updated the runtime dep.