### PR TITLE
aerospike: add missing mountpoint detection in pre checks

### DIFF
--- a/dev-db/aerospike-server-enterprise/files/aerospike.init
+++ b/dev-db/aerospike-server-enterprise/files/aerospike.init
@@ -46,6 +46,13 @@ start_pre() {
 	set_shmmax
 	ulimit -n 100000
 	if [ -n $LD_PRELOAD ]; then export LD_PRELOAD; fi
+	#checking index-on-disk mount points
+	for m in $(awk '/mount / { print $2}; ' /etc/aerospike/aerospike.conf); do
+            if ! grep -qs $m /proc/mounts; then
+                eerror "mountpoint $m is missing"
+                return 1
+            fi
+        done
 }
 
 start_post() {

--- a/dev-db/aerospike-server-enterprise/files/aerospike.init2
+++ b/dev-db/aerospike-server-enterprise/files/aerospike.init2
@@ -42,6 +42,13 @@ start_pre() {
 	set_shmmax
 	ulimit -n 100000
 	if [ -n $LD_PRELOAD ]; then export LD_PRELOAD; fi
+	#checking index-on-disk mount points
+	for m in $(awk '/mount / { print $2}; ' /etc/aerospike/aerospike.conf); do
+            if ! grep -qs $m /proc/mounts; then
+                eerror "mountpoint $m is missing"
+                return 1
+            fi
+        done
 }
 
 start_post() {


### PR DESCRIPTION
To prevent starting aerospike without it's index-on-disk mountpoints, we add the following checks in the init script.
related to adjust/infrastructure#16215