### PR TITLE
net-analyzer/logdna-agent/files/logdna.init: redirect stderr and stdout to logfile

### DIFF
--- a/net-analyzer/logdna-agent/files/logdna.init
+++ b/net-analyzer/logdna-agent/files/logdna.init
@@ -19,7 +19,7 @@ start() {
         check_config || return 1
         chmod 0644 /etc/logrotate.d/"${name}" > /dev/null 2>&1
         start-stop-daemon --background --start --exec "${command}" \
-        --make-pidfile --pidfile "${pid_file}" >> "${log_file}" 2>&1
+        --make-pidfile --pidfile "${pid_file}" --stdout "${log_file}" --stderr "${log_file}"
         eend $?
 }
 


### PR DESCRIPTION
Init script was redirecting the stdout and stderr in a way that didn't allow us to see the logs of the daemon. I changed it to use the --stderr and --stdout options of the start-stop-daemon command. Now it works