### PR TITLE
aerospike-prometheus-exporter: fix ebuild and init script

### DIFF
--- a/app-metrics/aerospike-prometheus-exporter/aerospike-prometheus-exporter-1.2.0.ebuild
+++ b/app-metrics/aerospike-prometheus-exporter/aerospike-prometheus-exporter-1.2.0.ebuild
@@ -496,15 +496,15 @@ src_install() {
 
 	# the below has not been modified and probably needs tidied up somewhat
 
-	newbin "${MY_PN}" "${PN}"
+	newbin "${PN}" "${PN}"
 	dodoc README.md
 
 	keepdir /var/lib/prometheus/"${MY_PN}" /var/log/prometheus
-	fowners "${EXPORTER_USER}" /var/lib/prometheus/"${MY_PN}" /var/log/prometheus
+	fowners prometheus-exporter:prometheus-exporter /var/lib/prometheus/"${MY_PN}" /var/log/prometheus
 
 	insinto /etc/prometheus
-
 	newinitd "${FILESDIR}/${PN}.initd" "${PN}"
 	insinto /etc/aerospike-prometheus-exporter/
+	fowners prometheus-exporter:prometheus-exporter /etc/aerospike-prometheus-exporter
 	newins "${FILESDIR}/ape.toml" "ape.toml"
 }

--- a/app-metrics/aerospike-prometheus-exporter/files/aerospike-prometheus-exporter.initd
+++ b/app-metrics/aerospike-prometheus-exporter/files/aerospike-prometheus-exporter.initd
@@ -8,13 +8,12 @@ pidfile="/run/${SVCNAME}/${SVCNAME}.pid"
 user="prometheus-exporter"
 
 command="/usr/bin/${SVCNAME}"
-command_args="${command_args}"
+command_args="${command_args} --config /etc/aerospike-prometheus-exporter/ape.toml"
 command_background="true"
 command_user="${user}"
 output_log="/var/log/prometheus/${SVCNAME}.log"
 error_log="/var/log/prometheus/${SVCNAME}.log"
-start_stop_daemon_args="--wait 1000 \
-    --config /etc/aerospike-prometheus-exporter/ape.toml"
+start_stop_daemon_args="--wait 1000"
 
 depend() {
 	need net
@@ -22,9 +21,5 @@ depend() {
 }
 
 start_pre() {
-	if [[ -z ${DATA_SOURCE_NAME} ]]; then
-		ewarn "DATA_SOURCE_NAME not set"
-		exit 1
-	fi
 	checkpath -d -m 0755 -o "${user}" "${pidfile%/*}"
 }


### PR DESCRIPTION
Ebuild had some issues that didn't allow proper installation + missing ownership of certain directories change. 
Init script had a minor issues that prevented from starting the daemon.
related to adjust/infrastructure#17556