### PR TITLE
net-proxy/nutcrackers: bump to EAPI=8

### DIFF
--- a/net-proxy/nutcrackers/nutcrackers-1.2.1.ebuild
+++ b/net-proxy/nutcrackers/nutcrackers-1.2.1.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=8
 
-inherit autotools eutils
+inherit autotools
 
 DESCRIPTION="Multithreaded Nutcracker (Twemproxy)"
 HOMEPAGE="https://github.com/vipshop/twemproxies"
@@ -19,8 +19,12 @@ RDEPEND="${DEPEND}"
 
 S="${WORKDIR}/twemproxies-${PV}"
 
+PATCHES=(
+	"${FILESDIR}/${P}-use-system-libyaml.patch"
+)
+
 src_prepare() {
-	epatch "${FILESDIR}/${PN}-${PV}-use-system-libyaml.patch"
+	default
 	eautoreconf
 }
 

--- a/net-proxy/nutcrackers/nutcrackers-1.2.2.ebuild
+++ b/net-proxy/nutcrackers/nutcrackers-1.2.2.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2018 Gentoo Foundation
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=8
 
-inherit autotools eutils
+inherit autotools
 
 DESCRIPTION="Multithreaded Nutcracker (Twemproxy)"
 HOMEPAGE="https://github.com/vipshop/twemproxies"
@@ -19,8 +19,12 @@ RDEPEND="${DEPEND}"
 
 S="${WORKDIR}/nutcrackers"
 
+PATCHES=(
+	"${FILESDIR}/${PN}-1.2.1-use-system-libyaml.patch"
+)
+
 src_prepare() {
-	epatch "${FILESDIR}/${PN}-1.2.1-use-system-libyaml.patch"
+	default
 	eautoreconf
 }
 


### PR DESCRIPTION
EAPI 5 is no longer supported by autotools eclass