### PR TITLE
eclass/linux-mod.eclass: backport EAPI 8 update

### DIFF
--- a/eclass/linux-mod.eclass
+++ b/eclass/linux-mod.eclass
@@ -1,4 +1,4 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2022 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: linux-mod.eclass
@@ -7,7 +7,7 @@
 # @AUTHOR:
 # John Mylchreest <johnm@gentoo.org>,
 # Stefan Schweizer <genstef@gentoo.org>
-# @SUPPORTED_EAPIS: 5 6 7
+# @SUPPORTED_EAPIS: 6 7 8
 # @PROVIDES: linux-info
 # @BLURB: It provides the functionality required to install external modules against a kernel source tree.
 # @DESCRIPTION:
@@ -19,14 +19,14 @@
 # A Couple of env vars are available to effect usage of this eclass
 # These are as follows:
 
-# @ECLASS-VARIABLE: MODULES_OPTIONAL_USE
+# @ECLASS_VARIABLE: MODULES_OPTIONAL_USE
 # @PRE_INHERIT
 # @DEFAULT_UNSET
 # @DESCRIPTION:
 # A string containing the USE flag to use for making this eclass optional
 # The recommended non-empty value is 'modules'
 
-# @ECLASS-VARIABLE: MODULES_OPTIONAL_USE_IUSE_DEFAULT
+# @ECLASS_VARIABLE: MODULES_OPTIONAL_USE_IUSE_DEFAULT
 # @PRE_INHERIT
 # @DEFAULT_UNSET
 # @DESCRIPTION:
@@ -34,29 +34,29 @@
 # flag. Default value is unset (false). True represented by 1 or 'on', other
 # values including unset treated as false.
 
-# @ECLASS-VARIABLE: KERNEL_DIR
+# @ECLASS_VARIABLE: KERNEL_DIR
 # @DESCRIPTION:
 # A string containing the directory of the target kernel sources. The default value is
 # "/usr/src/linux"
 : ${KERNEL_DIR:=/usr/src/linux}
 
-# @ECLASS-VARIABLE: ECONF_PARAMS
+# @ECLASS_VARIABLE: ECONF_PARAMS
 # @DEFAULT_UNSET
 # @DESCRIPTION:
 # It's a string containing the parameters to pass to econf.
 # If this is not set, then econf isn't run.
 
-# @ECLASS-VARIABLE: BUILD_PARAMS
+# @ECLASS_VARIABLE: BUILD_PARAMS
 # @DEFAULT_UNSET
 # @DESCRIPTION:
 # It's a string with the parameters to pass to emake.
 
-# @ECLASS-VARIABLE: BUILD_TARGETS
+# @ECLASS_VARIABLE: BUILD_TARGETS
 # @DESCRIPTION:
 # It's a string with the build targets to pass to make. The default value is "clean module"
 : ${BUILD_TARGETS:=clean module}
 
-# @ECLASS-VARIABLE: MODULE_NAMES
+# @ECLASS_VARIABLE: MODULE_NAMES
 # @DEFAULT_UNSET
 # @DESCRIPTION:
 # It's a string containing the modules to be built automatically using the default
@@ -101,14 +101,14 @@
 # There is also support for automated modprobe.d file generation.
 # This can be explicitly enabled by setting any of the following variables.
 
-# @ECLASS-VARIABLE: MODULESD_<modulename>_ENABLED
+# @ECLASS_VARIABLE: MODULESD_<modulename>_ENABLED
 # @DEFAULT_UNSET
 # @DESCRIPTION:
 # This is used to disable the modprobe.d file generation otherwise the file will be
 # always generated (unless no MODULESD_<modulename>_* variable is provided). Set to "no" to disable
 # the generation of the file and the installation of the documentation.
 
-# @ECLASS-VARIABLE: MODULESD_<modulename>_EXAMPLES
+# @ECLASS_VARIABLE: MODULESD_<modulename>_EXAMPLES
 # @DEFAULT_UNSET
 # @DESCRIPTION:
 # This is a bash array containing a list of examples which should
@@ -120,7 +120,7 @@
 #
 # where array_component is "<modulename> options" (see modprobe.conf(5))
 
-# @ECLASS-VARIABLE: MODULESD_<modulename>_ALIASES
+# @ECLASS_VARIABLE: MODULESD_<modulename>_ALIASES
 # @DEFAULT_UNSET
 # @DESCRIPTION:
 # This is a bash array containing a list of associated aliases.
@@ -131,26 +131,30 @@
 #
 # where array_component is "wildcard <modulename>" (see modprobe.conf(5))
 
-# @ECLASS-VARIABLE: MODULESD_<modulename>_ADDITIONS
+# @ECLASS_VARIABLE: MODULESD_<modulename>_ADDITIONS
 # @DEFAULT_UNSET
 # @DESCRIPTION:
 # This is a bash array containing a list of additional things to
 # add to the bottom of the file. This can be absolutely anything.
 # Each entry is a new line.
 
-# @ECLASS-VARIABLE: MODULESD_<modulename>_DOCS
+# @ECLASS_VARIABLE: MODULESD_<modulename>_DOCS
 # @DEFAULT_UNSET
 # @DESCRIPTION:
 # This is a string list which contains the full path to any associated
 # documents for <modulename>. These files are installed in the live tree.
 
-# @ECLASS-VARIABLE: KV_OBJ
+# @ECLASS_VARIABLE: KV_OBJ
 # @INTERNAL
 # @DESCRIPTION:
 # It's a read-only variable. It contains the extension of the kernel modules.
 
 case ${EAPI:-0} in
-	[567]) inherit eutils ;;
+	[67])
+		inherit eutils
+		;;
+	8)
+		;;
 	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
 esac
 
@@ -182,53 +186,13 @@ RDEPEND="
 		)
 	${MODULES_OPTIONAL_USE:+)}"
 DEPEND="${RDEPEND}
-    ${MODULES_OPTIONAL_USE}${MODULES_OPTIONAL_USE:+? (}
+	${MODULES_OPTIONAL_USE}${MODULES_OPTIONAL_USE:+? (}
 	sys-apps/sed
 	kernel_linux? ( virtual/linux-sources virtual/libelf )
 	${MODULES_OPTIONAL_USE:+)}"
 
 # eclass utilities
 # ----------------------------------
-
-check_vermagic() {
-	debug-print-function ${FUNCNAME} $*
-
-	local curr_gcc_ver=$(gcc -dumpversion)
-	local tmpfile old_chost old_gcc_ver result=0
-	[ -n "${MODULES_OPTIONAL_USE}" ] && use !${MODULES_OPTIONAL_USE} && return
-
-	tmpfile=`find "${KV_DIR}/" -iname "*.o.cmd" -exec grep usr/lib/gcc {} \; -quit`
-	tmpfile=${tmpfile//*usr/lib}
-	tmpfile=${tmpfile//\/include*}
-	old_chost=${tmpfile//*gcc\/}
-	old_chost=${old_chost//\/*}
-	old_gcc_ver=${tmpfile//*\/}
-
-	if [[ -z ${old_gcc_ver} || -z ${old_chost} ]]; then
-		ewarn ""
-		ewarn "Unable to detect what version of GCC was used to compile"
-		ewarn "the kernel. Build will continue, but you may experience problems."
-	elif [[ ${curr_gcc_ver} != ${old_gcc_ver} ]]; then
-		ewarn ""
-		ewarn "The version of GCC you are using (${curr_gcc_ver}) does"
-		ewarn "not match the version of GCC used to compile the"
-		ewarn "kernel (${old_gcc_ver})."
-		result=1
-	elif [[ ${CHOST} != ${old_chost} ]]; then
-		ewarn ""
-		ewarn "The current CHOST (${CHOST}) does not match the chost"
-		ewarn "used when compiling the kernel (${old_chost})."
-		result=1
-	fi
-
-	if [[ ${result} -gt 0 ]]; then
-		ewarn ""
-		ewarn "Build will not continue, because you will experience problems."
-		ewarn "To fix this either change the version of GCC you wish to use"
-		ewarn "to match the kernel, or recompile the kernel first."
-		die "GCC Version Mismatch."
-	fi
-}
 
 # @FUNCTION: use_m
 # @RETURN: true or false
@@ -264,11 +228,10 @@ convert_to_m() {
 	fi
 }
 
-# internal function
-#
-# FUNCTION: update_depmod
-# DESCRIPTION:
-# It updates the modules.dep file for the current kernel.
+# @FUNCTION: update_depmod
+# @INTERNAL
+# @DESCRIPTION:
+# Updates the modules.dep file for the current kernel.
 update_depmod() {
 	debug-print-function ${FUNCNAME} $*
 
@@ -289,11 +252,10 @@ update_depmod() {
 	fi
 }
 
-# internal function
-#
-# FUNCTION: move_old_moduledb
-# DESCRIPTION:
-# It updates the location of the database used by the module-rebuild utility.
+# @FUNCTION: move_old_moduledb
+# @INTERNAL
+# @DESCRIPTION:
+# Updates the location of the database used by the module-rebuild utility.
 move_old_moduledb() {
 	debug-print-function ${FUNCNAME} $*
 
@@ -309,11 +271,9 @@ move_old_moduledb() {
 	fi
 }
 
-# internal function
-#
-# FUNCTION: update_moduledb
-# DESCRIPTION:
-# It adds the package to the /var/lib/module-rebuild/moduledb database used by the module-rebuild utility.
+# @FUNCTION: update_moduledb
+# @DESCRIPTION:
+# Adds the package to the /var/lib/module-rebuild/moduledb database used by the module-rebuild utility.
 update_moduledb() {
 	debug-print-function ${FUNCNAME} $*
 
@@ -331,12 +291,9 @@ update_moduledb() {
 	fi
 }
 
-# internal function
-#
-# FUNCTION: remove_moduledb
-# DESCRIPTION:
-# It removes the package from the /var/lib/module-rebuild/moduledb database used by
-# the module-rebuild utility.
+# @FUNCTION: remove_moduledb
+# @DESCRIPTION:
+# Removes the package from the /var/lib/module-rebuild/moduledb database used by
 remove_moduledb() {
 	debug-print-function ${FUNCNAME} $*
 
@@ -366,6 +323,10 @@ set_kvobj() {
 	# einfo "Using KV_OBJ=${KV_OBJ}"
 }
 
+# @FUNCTION: get-KERNEL_CC
+# @RETURN: Name of the C compiler.
+# @DESCRIPTION:
+# Return name of the C compiler while honoring variables defined in ebuilds.
 get-KERNEL_CC() {
 	debug-print-function ${FUNCNAME} $*
 
@@ -386,12 +347,11 @@ get-KERNEL_CC() {
 	echo "${kernel_cc}"
 }
 
-# internal function
-#
-# FUNCTION:
-# USAGE: /path/to/the/modulename_without_extension
-# RETURN: A file in /etc/modprobe.d
-# DESCRIPTION:
+# @FUNCTION: generate_modulesd
+# @INTERNAL
+# @USAGE: /path/to/the/modulename_without_extension
+# @RETURN: A file in /etc/modprobe.d
+# @DESCRIPTION:
 # This function will generate and install the neccessary modprobe.d file from the
 # information contained in the modules exported parms.
 # (see the variables MODULESD_<modulename>_ENABLED, MODULESD_<modulename>_EXAMPLES,
@@ -402,8 +362,8 @@ generate_modulesd() {
 	debug-print-function ${FUNCNAME} $*
 	[ -n "${MODULES_OPTIONAL_USE}" ] && use !${MODULES_OPTIONAL_USE} && return
 
-	local 	currm_path currm currm_t t myIFS myVAR
-	local 	module_docs module_enabled module_aliases \
+	local currm_path currm currm_t t myIFS myVAR
+	local module_docs module_enabled module_aliases \
 			module_additions module_examples module_modinfo module_opts
 
 	for currm_path in ${@}
@@ -421,9 +381,9 @@ generate_modulesd() {
 		module_additions="$(eval echo \${#MODULESD_${currm_t}_ADDITIONS[*]})"
 		module_examples="$(eval echo \${#MODULESD_${currm_t}_EXAMPLES[*]})"
 
-		[[ ${module_aliases} -eq 0 ]] 	&& unset module_aliases
+		[[ ${module_aliases} -eq 0 ]]	&& unset module_aliases
 		[[ ${module_additions} -eq 0 ]]	&& unset module_additions
-		[[ ${module_examples} -eq 0 ]] 	&& unset module_examples
+		[[ ${module_examples} -eq 0 ]]  && unset module_examples
 
 		# If we specify we dont want it, then lets exit, otherwise we assume
 		# that if its set, we do want it.
@@ -540,12 +500,11 @@ generate_modulesd() {
 	return 0
 }
 
-# internal function
-#
-# FUNCTION: find_module_params
-# USAGE: A string "NAME(LIBDIR:SRCDIR:OBJDIR)"
-# RETURN: The string "modulename:NAME libdir:LIBDIR srcdir:SRCDIR objdir:OBJDIR"
-# DESCRIPTION:
+# @FUNCTION: find_module_params
+# @USAGE: A string "NAME(LIBDIR:SRCDIR:OBJDIR)"
+# @INTERNAL
+# @RETURN: The string "modulename:NAME libdir:LIBDIR srcdir:SRCDIR objdir:OBJDIR"
+# @DESCRIPTION:
 # Analyze the specification NAME(LIBDIR:SRCDIR:OBJDIR) of one module as described in MODULE_NAMES.
 find_module_params() {
 	debug-print-function ${FUNCNAME} $*
@@ -604,11 +563,6 @@ linux-mod_pkg_setup() {
 	local is_bin="${MERGE_TYPE}"
 
 	# If we are installing a binpkg, take a different path.
-	# use MERGE_TYPE if available (eapi>=4); else use non-PMS EMERGE_FROM (eapi<4)
-	if has ${EAPI} 0 1 2 3; then
-		is_bin=${EMERGE_FROM}
-	fi
-
 	if [[ ${is_bin} == binary ]]; then
 		linux-mod_pkg_setup_binary
 		return
@@ -623,10 +577,6 @@ linux-mod_pkg_setup() {
 	strip_modulenames;
 	[[ -n ${MODULE_NAMES} ]] && check_modules_supported
 	set_kvobj;
-	# Commented out with permission from johnm until a fixed version for arches
-	# who intentionally use different kernel and userland compilers can be
-	# introduced - Jason Wever <weeve@gentoo.org>, 23 Oct 2005
-	#check_vermagic;
 }
 
 # @FUNCTION: linux-mod_pkg_setup_binary
@@ -647,6 +597,9 @@ linux-mod_pkg_setup_binary() {
 	linux-info_pkg_setup;
 }
 
+# @FUNCTION: strip_modulenames
+# @DESCRIPTION:
+# Remove modules from being built automatically using the default src_compile/src_install
 strip_modulenames() {
 	debug-print-function ${FUNCNAME} $*
 
@@ -721,13 +674,13 @@ linux-mod_src_compile() {
 		fi
 	done
 
-	set_arch_to_portage
+	set_arch_to_pkgmgr
 	ABI="${myABI}"
 }
 
 # @FUNCTION: linux-mod_src_install
 # @DESCRIPTION:
-# It install the modules specified in MODULES_NAME. The modules should be inside the ${objdir}
+# It install the modules specified in MODULE_NAMES. The modules should be inside the ${objdir}
 # directory and they are installed inside /lib/modules/${KV_FULL}/${libdir}.
 #
 # The modprobe.d configuration file is automatically generated if the
@@ -759,8 +712,27 @@ linux-mod_src_install() {
 		einfo "Installing ${modulename} module"
 		cd "${objdir}" || die "${objdir} does not exist"
 		insinto "${INSTALL_MOD_PATH}"/lib/modules/${KV_FULL}/${libdir}
-		doins ${modulename}.${KV_OBJ} || die "doins ${modulename}.${KV_OBJ} failed"
-		cd "${OLDPWD}"
+
+		# check here for CONFIG_MODULE_COMPRESS_<compression option> (NONE, GZIP, XZ, ZSTD)
+		# and similarily compress the module being built if != NONE.
+
+		if linux_chkconfig_present MODULE_COMPRESS_XZ; then
+			xz -T$(makeopts_jobs) --memlimit-compress=50% -q ${modulename}.${KV_OBJ} || die "Compressing ${modulename}.${KV_OBJ} with xz failed"
+			doins ${modulename}.${KV_OBJ}.xz
+		elif linux_chkconfig_present MODULE_COMPRESS_GZIP; then
+			if type -P pigz &>/dev/null ; then
+				pigz -p$(makeopts_jobs) ${modulename}.${KV_OBJ} || die "Compressing ${modulename}.${KV_OBJ} with pigz failed"
+			else
+				gzip ${modulename}.${KV_OBJ} || die "Compressing ${modulename}.${KV_OBJ} with gzip failed"
+			fi
+			doins ${modulename}.${KV_OBJ}.gz
+		elif linux_chkconfig_present MODULE_COMPRESS_ZSTD; then
+			zstd -T$(makeopts_jobs) ${modulename}.${KV_OBJ} || "Compressing ${modulename}.${KV_OBJ} with zstd failed"
+			doins ${modulename}.${KV_OBJ}.zst
+		else
+			doins ${modulename}.${KV_OBJ}
+		fi
+		cd "${OLDPWD}" || die "${OLDPWD} does not exist"
 
 		generate_modulesd "${objdir}/${modulename}"
 	done

--- a/eclass/linux-mod.eclass
+++ b/eclass/linux-mod.eclass
@@ -163,7 +163,7 @@ _LINUX_MOD_ECLASS=1
 
 # TODO: When adding support for future EAPIs, please audit this list
 # for unused inherits and conditionalise them.
-inherit linux-info multilib toolchain-funcs
+inherit linux-info multilib multiprocessing toolchain-funcs
 
 case ${MODULES_OPTIONAL_USE_IUSE_DEFAULT:-n} in
   [nNfF]*|[oO][fF]*|0|-) _modules_optional_use_iuse_default='' ;;


### PR DESCRIPTION
Base gentoo repo eclasses are updated, EAPI 5 has been deprecated and some ebuilds depend on the new EAPI version.

Relevant changes:
 - EAPI 8 doesn't use eutils
 - check_vermagic is removed on upstream, and doesn't seem to be used on our ebuilds
 - Remove support for EAPI < 4. Removed from upstream and also not used on our tree
 - set_arch_to_portage -> set_arch_to_pkgmgr: same function, but name was changed in upstream
 - Take advantage of compressed modules if supported by kernel configuration.