### PR TITLE
app-metrics/aerospike-prometheus-exporter/ fix username

### DIFF
--- a/app-metrics/aerospike-prometheus-exporter/aerospike-prometheus-exporter-1.2.0-r1.ebuild
+++ b/app-metrics/aerospike-prometheus-exporter/aerospike-prometheus-exporter-1.2.0-r1.ebuild
@@ -498,11 +498,11 @@ src_install() {
 	dodoc README.md
 
 	keepdir /var/lib/prometheus/"${MY_PN}" /var/log/prometheus
-	fowners prometheus-exporter:prometheus-exporter /var/lib/prometheus/"${MY_PN}" /var/log/prometheus
+	fowners aerospike-prometheus-exporter:aerospike-prometheus-exporter /var/lib/prometheus/"${MY_PN}" /var/log/prometheus
 
 	insinto /etc/prometheus
 	newinitd "${FILESDIR}/${PN}.initd" "${PN}"
 	insinto /etc/aerospike-prometheus-exporter/
-	fowners prometheus-exporter:prometheus-exporter /etc/aerospike-prometheus-exporter
+	fowners aerospike-prometheus-exporter:aerospike-prometheus-exporter /etc/aerospike-prometheus-exporter
 	newins "${FILESDIR}/ape.toml" "ape.toml"
 }

--- a/app-metrics/aerospike-prometheus-exporter/files/aerospike-prometheus-exporter.initd
+++ b/app-metrics/aerospike-prometheus-exporter/files/aerospike-prometheus-exporter.initd
@@ -5,7 +5,7 @@
 description="Aerospike's monitoring agent for Prometheus"
 name="Aerospike Prometheus Exporter"
 pidfile="/run/${SVCNAME}/${SVCNAME}.pid"
-user="prometheus-exporter"
+user="aerospike-prometheus-exporter"
 
 command="/usr/bin/${SVCNAME}"
 command_args="${command_args} --config /etc/aerospike-prometheus-exporter/ape.toml"


### PR DESCRIPTION
Fixing the username for aerospike-prometheus-exporter as it was incorrectly set to `prometheus-exporter` instead of `aerospike-prometheus-exporter`