### PR TITLE
Run tyk by nonroot user (#808)

### DIFF
--- a/net-misc/tyk-gateway-bin/files/tyk-gateway.initd
+++ b/net-misc/tyk-gateway-bin/files/tyk-gateway.initd
@@ -7,6 +7,7 @@ description="tyk is an API access control"
 command="/opt/bin/tyk"
 command_args="--conf /etc/tyk.conf"
 command_background="true"
+command_user=tyk
 pidfile="/var/run/${RC_SVCNAME}.pid"
 output_logger="logger -p daemon.info -t ${SVCNAME}"
 error_logger="logger -p daemon.error -t ${SVCNAME}"

--- a/net-misc/tyk-gateway-bin/tyk-gateway-bin-4.0.6.ebuild
+++ b/net-misc/tyk-gateway-bin/tyk-gateway-bin-4.0.6.ebuild
@@ -30,6 +30,11 @@ src_prepare() {
 	rm -r lib etc opt/share opt/tyk-gateway/install opt/tyk || die
 }
 
+pkg_preinst() {
+  /usr/sbin/useradd -r tyk -d /opt/tyk-gateway -s /sbin/nologin
+}
+
+
 src_install() {
 	newinitd "${FILESDIR}/tyk-gateway.initd" "tyk-gateway"
 	insinto /etc


### PR DESCRIPTION
Signed-off-by: Sassan <sassan.torabkheslat@adjust.com>

For security and performance purposes, we should jail Tyk Gateway Service to a non-root user.
if (for any reason) the tyk-gateway service is compromised, we lose everything, because it is running with root user privileges.