### PR TITLE
pgtelemetr - add pg15 to the POSTGRES_COMPAT

### DIFF
--- a/dev-db/pgtelemetry/pgtelemetry-1.0.0.ebuild
+++ b/dev-db/pgtelemetry/pgtelemetry-1.0.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-POSTGRES_COMPAT=( 9.6 10 11 12 )
+POSTGRES_COMPAT=( 9.6 10 11 12 15 )
 
 inherit postgres-multi
 


### PR DESCRIPTION
Add pg15 to the POSTGRES_COMPAT, so we can install dev-db/pgtelemetry beside postgrSQL 15.