### PR TITLE
eclass/python-utils-r1.eclass: add python3_12 in python patterns

### DIFF
--- a/eclass/python-utils-r1.eclass
+++ b/eclass/python-utils-r1.eclass
@@ -43,7 +43,7 @@ inherit multiprocessing toolchain-funcs
 # All supported Python implementations, most preferred last.
 _PYTHON_ALL_IMPLS=(
 	pypy3
-	python3_{5..11}
+	python3_{5..12}
 )
 readonly _PYTHON_ALL_IMPLS
 
@@ -83,7 +83,7 @@ _python_verify_patterns() {
 	local impl pattern
 	for pattern; do
 		case ${pattern} in
-			-[23]|3.[89]|3.1[01])
+			-[23]|3.[89]|3.1[012])
 				continue
 				;;
 		esac
@@ -132,7 +132,7 @@ _python_set_impls() {
 			# please keep them in sync with _PYTHON_ALL_IMPLS
 			# and _PYTHON_HISTORICAL_IMPLS
 			case ${i} in
-				pypy3|python2_7|python3_[89]|python3_1[01])
+				pypy3|python2_7|python3_[89]|python3_1[0-2])
 					;;
 				jython2_7|pypy|pypy1_[89]|pypy2_0|python2_[5-6]|python3_[1-7])
 					obsolete+=( "${i}" )
@@ -245,7 +245,7 @@ _python_impl_matches() {
 				[[ ${impl} == python${pattern/./_} || ${impl} == pypy3 ]] &&
 					return 0
 				;;
-			3.8|3.1[01])
+			3.8|3.1[0-2])
 				[[ ${impl} == python${pattern/./_} ]] && return 0
 				;;
 			*)


### PR DESCRIPTION
This will fix emerge complaint about ebuilds using python3_12 as python implementation. 
Our eclass python-utils-r1 was not python3_12 aware.