### PR TITLE
Add postgresql 15 compat to postgresql extension packages

### DIFF
--- a/dev-db/base36/base36-0.0.1.ebuild
+++ b/dev-db/base36/base36-0.0.1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-POSTGRES_COMPAT=( 9.6 10 11 12 )
+POSTGRES_COMPAT=( 9.6 10 11 12 15 )
 
 inherit postgres-multi
 

--- a/dev-db/country/country-0.0.2.ebuild
+++ b/dev-db/country/country-0.0.2.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-POSTGRES_COMPAT=( 9.6 10 11 12 )
+POSTGRES_COMPAT=( 9.6 10 11 12 15 )
 
 inherit postgres-multi
 

--- a/dev-db/currency/currency-0.0.2-r1.ebuild
+++ b/dev-db/currency/currency-0.0.2-r1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-POSTGRES_COMPAT=( 9.6 10 11 12 )
+POSTGRES_COMPAT=( 9.6 10 11 12 15 )
 
 inherit postgres-multi
 

--- a/dev-db/device_type/device_type-0.0.1.ebuild
+++ b/dev-db/device_type/device_type-0.0.1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-POSTGRES_COMPAT=( 9.6 10 11 12 )
+POSTGRES_COMPAT=( 9.6 10 11 12 15 )
 
 inherit postgres-multi
 

--- a/dev-db/hashtypes/hashtypes-0.1.3.ebuild
+++ b/dev-db/hashtypes/hashtypes-0.1.3.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-POSTGRES_COMPAT=( 9.6 10 11 12 )
+POSTGRES_COMPAT=( 9.6 10 11 12 15 )
 
 inherit postgres-multi
 

--- a/dev-db/istore/istore-0.1.11.ebuild
+++ b/dev-db/istore/istore-0.1.11.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-POSTGRES_COMPAT=( 9.6 10 11 12 )
+POSTGRES_COMPAT=( 9.6 10 11 12 15 )
 
 inherit postgres-multi
 

--- a/dev-db/os_name/os_name-0.0.2.ebuild
+++ b/dev-db/os_name/os_name-0.0.2.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-POSTGRES_COMPAT=( 9.6 10 11 12 )
+POSTGRES_COMPAT=( 9.6 10 11 12 15 )
 
 inherit postgres-multi
 


### PR DESCRIPTION
dev-db/istore: add postgresql-15 compat
dev-db/hashtypes: add postgresql-15 compat
dev-db/device_type: add postgresql-15 compat
dev-db/currency: add postgresql-15 compat
dev-db/country: add postgresql-15 compat
dev-db/base36: add postgresql-15 compat
dev-db/os_name: add postgresql-15 compat