### PR TITLE
create nutcracker exporter for prometheus

### DIFF
--- a/app-metrics/twemproxy_exporter/files/nutcracker_exporter.confd
+++ b/app-metrics/twemproxy_exporter/files/nutcracker_exporter.confd
@@ -1,0 +1,2 @@
+# arguments for ceph exporter
+command_args="-web.listen-address 0.0.0.0:9012 -twemproxy.stats-address localhost:12"

--- a/app-metrics/twemproxy_exporter/files/nutcracker_exporter.initd
+++ b/app-metrics/twemproxy_exporter/files/nutcracker_exporter.initd
@@ -1,0 +1,16 @@
+#!/sbin/openrc-run
+# Copyright 2016-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+description="Nutcracker metrics exporter"
+pidfile=${pidfile:-"/run/${RC_SVCNAME}.pid"}
+user=${user:-nobody}
+group=${group:-nobody}
+
+command="/usr/bin/nutcracker_exporter"
+command_background="true"
+start_stop_daemon_args="--user ${user} --group ${group}"
+
+depend() {
+	after net
+}

--- a/app-metrics/twemproxy_exporter/files/nutcracker_socket_exporter.confd
+++ b/app-metrics/twemproxy_exporter/files/nutcracker_socket_exporter.confd
@@ -1,0 +1,2 @@
+# arguments for ceph exporter
+command_args="-web.listen-address 0.0.0.0:9146 -twemproxy.stats-address localhost:146"

--- a/app-metrics/twemproxy_exporter/files/nutcracker_socket_exporter.initd
+++ b/app-metrics/twemproxy_exporter/files/nutcracker_socket_exporter.initd
@@ -1,0 +1,16 @@
+#!/sbin/openrc-run
+# Copyright 2016-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+description="Nutcracker metrics exporter"
+pidfile=${pidfile:-"/run/${RC_SVCNAME}.pid"}
+user=${user:-nobody}
+group=${group:-nobody}
+
+command="/usr/bin/nutcracker_exporter"
+command_background="true"
+start_stop_daemon_args="--user ${user} --group ${group}"
+
+depend() {
+	after net
+}

--- a/app-metrics/twemproxy_exporter/metadata.xml
+++ b/app-metrics/twemproxy_exporter/metadata.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+<maintainer type="person">
+<email>sherif@adjust.com</email>
+<name>Sherif Labib</name>
+</maintainer>
+</pkgmetadata>

--- a/app-metrics/twemproxy_exporter/twemproxy_exporter-0.1.0.ebuild
+++ b/app-metrics/twemproxy_exporter/twemproxy_exporter-0.1.0.ebuild
@@ -1,0 +1,27 @@
+# Copyright 1999-2023 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+inherit go-module
+inherit git-r3
+
+DESCRIPTION="Prometheus exporter that scrapes metrics from a nutcracker"
+HOMEPAGE="https://github.com/stuartnelson3/twemproxy_exporter"
+EGIT_REPO_URI="https://github.com/stuartnelson3/twemproxy_exporter.git"
+LICENSE="Apache-2.0"
+SLOT="0"
+KEYWORDS="~amd64"
+
+DEPEND="dev-lang/go"
+
+src_compile() {
+		go build -o nutcracker_exporter || die
+}
+
+src_install() {
+		dobin nutcracker_exporter
+		newconfd "${FILESDIR}"/nutcracker_exporter.confd nutcracker_exporter
+		newinitd "${FILESDIR}"/nutcracker_exporter.initd nutcracker_exporter
+		newconfd "${FILESDIR}"/nutcracker_socket_exporter.confd nutcracker_socket_exporter
+		newinitd "${FILESDIR}"/nutcracker_socket_exporter.initd nutcracker_socket_exporter
+}


### PR DESCRIPTION
Create twemproxy exporter for prometheus to export nutcracker (twemproxy) stats from TCP port 12 ( nutcracker port case ) and port 146 ( nutcracker socket case ) to prometheus for better monitoring