### PR TITLE
Adding kibana.service file

### DIFF
--- a/www-apps/kibana-bin/files/kibana.service
+++ b/www-apps/kibana-bin/files/kibana.service
@@ -1,0 +1,22 @@
+[Unit]
+Description=Kibana Web Application
+After=network.target
+
+[Service]
+Environment=BABEL_CACHE_PATH=%C/kibana/.babelcache.json
+
+WorkingDirectory=/opt/kibana
+StateDirectory=kibana
+StateDirectoryMode=0750
+CacheDirectory=kibana
+CacheDirectoryMode=0750
+
+User=kibana
+Group=kibana
+
+# DATA_DIR should be set in config (path.data directive)
+# But to comply with OpenRC script, preserve this
+ExecStart=/opt/kibana/bin/kibana --config /etc/kibana/kibana.yml --path.data=%S/kibana
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Install of kibana-bin-6.6.1 added here: https://github.com/adjust/gentoo-overlay/pull/847 was failing not finding kibana.service file.
```
>>> Install www-apps/kibana-bin-6.6.1 into /var/tmp/portage/www-apps/kibana-bin-6.6.1/image
Traceback (most recent call last):
  File "/usr/lib/portage/python3.9/doins.py", line 609, in <module>
    sys.exit(main(sys.argv[1:]))
  File "/usr/lib/portage/python3.9/doins.py", line 598, in main
    if _doins(
  File "/usr/lib/portage/python3.9/doins.py", line 441, in _doins
    return install_runner.install_file(source, os.path.dirname(dest))
  File "/usr/lib/portage/python3.9/doins.py", line 375, in install_file
    return self._ins_runner.run(source, dest_dir)
  File "/usr/lib/portage/python3.9/doins.py", line 183, in run
    sstat = os.stat(source)
FileNotFoundError: [Errno 2] No such file or directory: b'/var/tmp/portage/www-apps/kibana-bin-6.6.1/files/kibana.service'
```
File was taken from here: https://github.com/gentoo/gentoo/tree/master/www-apps/kibana-bin/files