### PR TITLE
app-admin/schaufel: add missing replication option in init script

### DIFF
--- a/app-admin/bagger-tools/files/schaufel_listener-0.3.initd
+++ b/app-admin/bagger-tools/files/schaufel_listener-0.3.initd
@@ -43,6 +43,9 @@ fi
 		LISTENER_OPTS+=" -h ${HOSTNAME_OVERRIDE}"
 [ -n "${LISTENER_JOBS}" ] && \
 	LISTENER_OPTS+=" -j ${LISTENER_JOBS}"
+[ -n "${LISTENER_REPLICATION}" ] && \
+	LISTENER_OPTS+=" -r ${LISTENER_REPLICATION}"
+
 
 command=/usr/bin/listener.pl
 command_args="${LISTENER_OPTS}"

--- a/app-admin/bagger-tools/files/schaufel_listener-0.4.initd
+++ b/app-admin/bagger-tools/files/schaufel_listener-0.4.initd
@@ -43,6 +43,9 @@ fi
 		LISTENER_OPTS+=" -h ${HOSTNAME_OVERRIDE}"
 [ -n "${LISTENER_JOBS}" ] && \
 	LISTENER_OPTS+=" -j ${LISTENER_JOBS}"
+[ -n "${LISTENER_REPLICATION}" ] && \
+	LISTENER_OPTS+=" -r ${LISTENER_REPLICATION}"
+
 
 command=/usr/bin/listener.pl
 command_args="${LISTENER_OPTS}"

--- a/app-admin/bagger-tools/files/schaufel_listener-0.5.initd
+++ b/app-admin/bagger-tools/files/schaufel_listener-0.5.initd
@@ -43,6 +43,9 @@ fi
 		LISTENER_OPTS+=" -h ${HOSTNAME_OVERRIDE}"
 [ -n "${LISTENER_JOBS}" ] && \
 	LISTENER_OPTS+=" -j ${LISTENER_JOBS}"
+[ -n "${LISTENER_REPLICATION}" ] && \
+	LISTENER_OPTS+=" -r ${LISTENER_REPLICATION}"
+
 
 command=/usr/bin/listener.pl
 command_args="${LISTENER_OPTS}"

--- a/app-admin/bagger-tools/files/schaufel_listener-0.7.initd
+++ b/app-admin/bagger-tools/files/schaufel_listener-0.7.initd
@@ -43,6 +43,9 @@ fi
 		LISTENER_OPTS+=" -h ${HOSTNAME_OVERRIDE}"
 [ -n "${LISTENER_JOBS}" ] && \
 	LISTENER_OPTS+=" -j ${LISTENER_JOBS}"
+[ -n "${LISTENER_REPLICATION}" ] && \
+	LISTENER_OPTS+=" -r ${LISTENER_REPLICATION}"
+
 
 command=/usr/bin/listener.pl
 command_args="${LISTENER_OPTS}"


### PR DESCRIPTION
REPLICATION option was missing from being handled in the init script, it drove me crazy because i didn't assume at all that the issue was there.