### PR TITLE
upgrade the logstash EAPI version

### DIFF
--- a/app-admin/logstash-bin/logstash-bin-6.8.15.ebuild
+++ b/app-admin/logstash-bin/logstash-bin-6.8.15.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
 inherit java-pkg-2
 


### PR DESCRIPTION
Manual installation and slack [discussion](https://adjust.slack.com/archives/G01N6QY9NV7/p1737539374850759) for tracking.
```
 emerge --pretend app-admin/logstash-bin

Local copy of remote index is up-to-date and will be used.

These are the packages that would be merged, in order:

Calculating dependencies | * ERROR: sys-libs/glibc-2.27-r666::adjust failed (depend phase):
 *   prefix: EAPI 6 not supported
 *
 * Call stack:
 *                ebuild.sh, line 632:  Called source '/var/db/repos/adjust/sys-libs/glibc/glibc-2.27-r666.ebuild'
 *   glibc-2.27-r666.ebuild, line   6:  Called inherit 'prefix' 'eutils' 'versionator' 'toolchain-funcs' 'flag-o-matic' 'gnuconfig' 'multilib' 'systemd' 'multiprocessing'
 *                ebuild.sh, line 312:  Called __qa_source '/var/db/repos/gentoo/eclass/prefix.eclass'
 - *                ebuild.sh, line 123:  Called source '/var/db/repos/gentoo/eclass/prefix.eclass'
 *            prefix.eclass, line  20:  Called die
 * The specific snippet of code:
 *   	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
 *
 * If you need support, post the output of `emerge --info '=sys-libs/glibc-2.27-r666::adjust'`,
 * the complete build log and the output of `emerge -pqv '=sys-libs/glibc-2.27-r666::adjust'`.
 * Working directory: '/usr/lib/python3.12/site-packages'
 * S: '/var/tmp/portage/sys-libs/glibc-2.27-r666/work/glibc-2.27'
... done!
Dependency resolution took 9.65 s (backtrack: 0/100).

[ebuild  NS    ] dev-java/openjdk-bin-8.432_p06 [21.0.5_p11] USE="-examples%"
[ebuild  NS    ] virtual/jdk-1.8.0-r9 [21]
[ebuild  NS    ] virtual/jre-1.8.0-r3 [21]
[ebuild  N    ~] app-admin/logstash-bin-6.8.15  USE="x-pack"
