### PR TITLE
python-consul: bump version

### DIFF
--- a/dev-python/python-consul/python-consul-1.1.0-r1.ebuild
+++ b/dev-python/python-consul/python-consul-1.1.0-r1.ebuild
@@ -1,9 +1,9 @@
-# Copyright 1999-2021 Gentoo Authors
+# Copyright 1999-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{8..9} )
+PYTHON_COMPAT=( python3_{8..13} )
 
 inherit distutils-r1
 
@@ -23,7 +23,7 @@ RDEPEND="dev-python/aiohttp[${PYTHON_USEDEP}]
 	>=dev-python/six-1.4[${PYTHON_USEDEP}]
 	dev-python/twisted[${PYTHON_USEDEP}]
 	>=dev-python/treq-16[${PYTHON_USEDEP}]
-	www-servers/tornado[${PYTHON_USEDEP}]
+	dev-python/tornado[${PYTHON_USEDEP}]
 "
 
 DEPEND="


### PR DESCRIPTION
Add supported python versions and rename tornado as the portage tree requires