### PR TITLE
PE-3145: add network-sandbox setting to an ebuild file

### DIFF
--- a/app-metrics/keepalived-exporter/keepalived-exporter-1.4.0.ebuild
+++ b/app-metrics/keepalived-exporter/keepalived-exporter-1.4.0.ebuild
@@ -21,6 +21,7 @@ COMMON_DEPEND="
 "
 RDEPEND="${COMMON_DEPEND}"
 SRC_DIR="${WORKDIR}/${P}"
+RESTRICT="network-sandbox"
 
 src_unpack() {
 	default


### PR DESCRIPTION
there's a small missing part for ebuild file in order to install go dependency