### PR TITLE
PE-3622: Fix jemalloc package to install on tr-backend-8 server

### DIFF
--- a/dev-libs/jemalloc/jemalloc-5.1.0.ebuild
+++ b/dev-libs/jemalloc/jemalloc-5.1.0.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=8
 
 inherit autotools toolchain-funcs multilib-minimal
 


### PR DESCRIPTION
```
tr-backend-8 ~ # emerge --info '=dev-libs/jemalloc-5.1.0::adjust
> '
 * ERROR: dev-libs/jemalloc-5.1.0::adjust failed (depend phase):
 *   autotools: EAPI 6 not supported
 *
 * Call stack:
 *               ebuild.sh, line 632:  Called source '/var/db/repos/adjust/dev-libs/jemalloc/jemalloc-5.1.0.ebuild'
 *   jemalloc-5.1.0.ebuild, line   6:  Called inherit 'autotools' 'toolchain-funcs' 'multilib-minimal'
 *               ebuild.sh, line 312:  Called __qa_source '/var/db/repos/gentoo/eclass/autotools.eclass'
 *               ebuild.sh, line 123:  Called source '/var/db/repos/gentoo/eclass/autotools.eclass'
 *        autotools.eclass, line  31:  Called die
 * The specific snippet of code:
 *   	*) die "${ECLASS}: EAPI ${EAPI:-0} not supported" ;;
 *
 * If you need support, post the output of `emerge --info '=dev-libs/jemalloc-5.1.0::adjust'`,
 * the complete build log and the output of `emerge -pqv '=dev-libs/jemalloc-5.1.0::adjust'`.
 * Working directory: '/usr/lib/python3.12/site-packages'
 * S: '/var/tmp/portage/dev-libs/jemalloc-5.1.0/work/jemalloc-5.1.0'
Portage 3.0.66.1 (python 3.12.7-final-0, default/linux/amd64/23.0/split-usr/no-multilib, gcc-14, glibc-2.40-r5, 6.1.119-debian x86_64)
```