### PR TITLE
PE-3831: Fix the python compatibility issue when python target set to  python3.11, python3.12

### DIFF
--- a/app-admin/superlance/superlance-2.0.0.ebuild
+++ b/app-admin/superlance/superlance-2.0.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_10 )
+PYTHON_COMPAT=( python3_10 python3_11 python3_12 )
 
 inherit distutils-r1
 


### PR DESCRIPTION
To fix the following error, when OS is using newer versions of PYTHON_TARGETS:
```
!!! All ebuilds that could satisfy ">=dev-python/setuptools-78.1.0[python_targets_python3_10(-)?]" have been masked.
!!! One of the following masked packages is required to complete your request:
- dev-python/setuptools-79.0.1::gentoo (masked by: corruption)
- dev-python/setuptools-79.0.0::gentoo (masked by: corruption)
- dev-python/setuptools-78.1.1::gentoo (masked by: corruption)
- dev-python/setuptools-78.1.0::gentoo (masked by: corruption)

(dependency required by "app-admin/superlance-2.0.0::adjust" [ebuild])
(dependency required by "app-admin/superlance" [argument])
```

More context here:
https://adjust.slack.com/archives/G01N6QY9NV7/p1745492715881439