### PR TITLE
update python-consul ebuild

### DIFF
--- a/dev-python/python-consul/python-consul-1.1.0-r1.ebuild
+++ b/dev-python/python-consul/python-consul-1.1.0-r1.ebuild
@@ -6,12 +6,13 @@ EAPI=8
 DISTUTILS_USE_PEP517=setuptools
 PYTHON_COMPAT=( python3_{11..13} )
 
-inherit distutils-r1
+inherit distutils-r1 pypi
 
 DESCRIPTION="Python client for Consul"
-HOMEPAGE="https://github.com/cablehead/python-consul/"
-SRC_URI="https://github.com/cablehead/python-consul/archive/v${PV}.tar.gz -> ${P}.tar.gz"
-
+HOMEPAGE="
+	https://pypi.org/project/python-consul/
+	https://github.com/python-consul/python-consul/
+"
 LICENSE="MIT"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"

--- a/dev-python/python-consul/python-consul-1.1.0-r1.ebuild
+++ b/dev-python/python-consul/python-consul-1.1.0-r1.ebuild
@@ -1,9 +1,10 @@
-# Copyright 1999-2025 Gentoo Authors
+# Copyright 1999-2026 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
-PYTHON_COMPAT=( python3_{8..13} )
+DISTUTILS_USE_PEP517=setuptools
+PYTHON_COMPAT=( python3_{11..13} )
 
 inherit distutils-r1
 
@@ -12,13 +13,11 @@ HOMEPAGE="https://github.com/cablehead/python-consul/"
 SRC_URI="https://github.com/cablehead/python-consul/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="MIT"
+SLOT="0"
 KEYWORDS="~amd64 ~x86"
 
-SLOT="0"
-
-IUSE="test"
-
-RDEPEND="dev-python/aiohttp[${PYTHON_USEDEP}]
+RDEPEND="
+	dev-python/aiohttp[${PYTHON_USEDEP}]
 	>=dev-python/requests-2.0[${PYTHON_USEDEP}]
 	>=dev-python/six-1.4[${PYTHON_USEDEP}]
 	dev-python/twisted[${PYTHON_USEDEP}]
@@ -26,16 +25,7 @@ RDEPEND="dev-python/aiohttp[${PYTHON_USEDEP}]
 	dev-python/tornado[${PYTHON_USEDEP}]
 "
 
-DEPEND="
-	test? (
-		dev-python/pytest[${PYTHON_USEDEP}]
-		${RDEPEND}
-	)
-"
+distutils_enable_tests pytest
 
 # needs pytest-twisted
 RESTRICT="test"
-
-python_test() {
-	py.test -v || die
-}


### PR DESCRIPTION
update python-consul ebuild

distutils-r1 no longer supports EAPI 7, so this package is currently masked.
Use DISTUTILS_USE_PEP517=setuptools for current distutils-r1 behavior and fetch
the 1.1.0 sdist from PyPI via pypi.eclass instead of relying on GitHub release
archives, since upstream does not publish GitHub releases for this project.